### PR TITLE
bazel: use distroless/static to base image

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -42,6 +42,7 @@ go_binary(
 go_image(
     name = "image",
     embed = [":go_default_library"],
+    pure = "on",
 )
 
 container_push(


### PR DESCRIPTION
## WHAT

Use `distroless/static:latest` to base image.

## WHY

More smallest container image.

## Note

You can create `distroless/static:debug` base image with
`bin/bazelisk build -c dbg --platforms=@io_bazel_rules_go//go/toolchain:linux_amd64 //:image`
command.

## Ref

- https://github.com/bazelbuild/rules_docker/blob/v0.12.1/go/image.bzl#L113