### PR TITLE
test: use a random db name when an env var is not given

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/cloudspannerecosystem/wrench
 require (
 	cloud.google.com/go/spanner v1.5.1
 	github.com/bazelbuild/bazelisk v0.0.8
+	github.com/google/uuid v1.1.1
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect
 	github.com/spf13/cobra v0.0.3
 	github.com/spf13/pflag v1.0.5 // indirect

--- a/go.sum
+++ b/go.sum
@@ -92,6 +92,8 @@ github.com/google/pprof v0.0.0-20191218002539-d4f498aebedc/go.mod h1:ZgVRPoUq/hf
 github.com/google/pprof v0.0.0-20200212024743-f11f1df84d12/go.mod h1:ZgVRPoUq/hfqzAqh7sHMqb3I9Rq5C59dIz2SbBwJ4eM=
 github.com/google/pprof v0.0.0-20200229191704-1ebb73c60ed3/go.mod h1:ZgVRPoUq/hfqzAqh7sHMqb3I9Rq5C59dIz2SbBwJ4eM=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
+github.com/google/uuid v1.1.1 h1:Gkbcsh/GbpXz7lPftLA3P6TYMwjCLYm83jiFQZF/3gY=
+github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+vpHVxEJEs9eg=
 github.com/googleapis/gax-go/v2 v2.0.5 h1:sjZBwGj9Jlw33ImPtvFviGYvseOtDM7hkSKB7+Tv3SM=
 github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5mhpdKc/us6bOk=

--- a/pkg/spanner/client_test.go
+++ b/pkg/spanner/client_test.go
@@ -21,11 +21,13 @@ package spanner
 
 import (
 	"context"
+	"fmt"
 	"io/ioutil"
 	"os"
 	"testing"
 
 	"cloud.google.com/go/spanner"
+	"github.com/google/uuid"
 	"google.golang.org/api/iterator"
 )
 
@@ -399,7 +401,8 @@ func testClientWithDatabase(t *testing.T, ctx context.Context) (*Client, func())
 	// TODO: take random database name and run tests parallelly.
 	database := os.Getenv(envSpannerDatabaseID)
 	if database == "" {
-		t.Fatalf("must set %s", envSpannerDatabaseID)
+		id := uuid.New()
+		database = fmt.Sprintf("wrench-test-%s", id.String()[:8])
 	}
 
 	config := &Config{


### PR DESCRIPTION
## WHAT

Assign a random UUID database name in tests when an env var is not given. 

## WHY

Somehow, it can happen that a database is deleted from another test and got the following error: 

```
    client_test.go:197: failed to apply mutation: spanner: code = "NotFound", desc = "Database not found: projects/*********************/instances/***************************/databases/***********"
=
```

Using a random UUID database name should resolve this issue. 