### PR TITLE
Add comment support #15

### DIFF
--- a/pkg/spanner/migration.go
+++ b/pkg/spanner/migration.go
@@ -20,7 +20,6 @@
 package spanner
 
 import (
-	"bytes"
 	"errors"
 	"fmt"
 	"io/ioutil"
@@ -44,6 +43,10 @@ var (
 	MigrationNameRegex = regexp.MustCompile(`[a-zA-Z0-9_\-]+`)
 
 	dmlRegex = regexp.MustCompile("^(UPDATE|DELETE)[\t\n\f\r ].*")
+
+	commentsRemovalRegex = regexp.MustCompile("(#[^\r\n]*|\\-\\-[^\r\n]*|\\/\\*[^\\*/]*?\\*\\/)")
+
+	commentsWhiteSpaceRemovalRegex = regexp.MustCompile("(?m)^\\\\s*\\r?\\n")
 )
 
 const (
@@ -138,7 +141,8 @@ func LoadMigrations(dir string) (Migrations, error) {
 }
 
 func toStatements(file []byte) []string {
-	contents := bytes.Split(file, []byte(statementsSeparator))
+	commentRemmoved := removeComments(string(file))
+	contents := strings.Split(commentRemmoved, statementsSeparator)
 
 	statements := make([]string, 0, len(contents))
 	for _, c := range contents {
@@ -146,8 +150,12 @@ func toStatements(file []byte) []string {
 			statements = append(statements, statement)
 		}
 	}
-
 	return statements
+}
+
+func removeComments(statement string) string {
+	s := commentsRemovalRegex.ReplaceAllString(statement, "")
+	return commentsWhiteSpaceRemovalRegex.ReplaceAllString(s, "")
 }
 
 func inspectStatementsKind(statements []string) (statementKind, error) {

--- a/pkg/spanner/testdata/schema.sql
+++ b/pkg/spanner/testdata/schema.sql
@@ -7,3 +7,7 @@ CREATE TABLE Singers (
   SingerID STRING(36) NOT NULL,
   FirstName STRING(1024),
 ) PRIMARY KEY(SingerID);
+
+CREATE TABLE TableWithComments (
+  ID STRING(36) NOT NULL,
+) PRIMARY KEY(ID);

--- a/pkg/spanner/testdata/schema_with_comment.sql
+++ b/pkg/spanner/testdata/schema_with_comment.sql
@@ -1,0 +1,21 @@
+CREATE TABLE SchemaMigrations (
+  Version INT64 NOT NULL,
+  Dirty BOOL NOT NULL,
+) PRIMARY KEY(Version);
+
+CREATE TABLE Singers (
+  SingerID STRING(36) NOT NULL,
+  FirstName STRING(1024),
+) PRIMARY KEY(SingerID);
+
+# this is an inline comment
+CREATE TABLE TableWithComments (
+  /* this is a multiline comment
+  on two lines */
+  ID STRING(36) NOT NULL, -- this is an inline comment
+  /* this is an inline comment */
+
+  /* column commented out
+  Name STRING(36) NOT NULL
+   */
+) PRIMARY KEY(ID); # another comment


### PR DESCRIPTION
<!--
Please read the contribution guidelines and the CLA carefully before
submitting your pull request.

https://cla.developers.google.com/
-->

## WHAT

* Add supports comments in DDL; only manual addition
  * I know there's already issue to store the comments both in importing and exporting on #15, but it supports only manual addition of comments so that we can leave some comments and restored them on local if they are missed by other wrench operation, temporarily


## WHY

* Supporting [comments](https://cloud.google.com/spanner/docs/lexical#comments) on DDL is helpful, if it is only manual addition temporarily

<!--
Write the motivation why you submit this pull request
-->
