### PR TITLE
Automated Release Builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,20 @@
+on:
+  release:
+    types: [created]
+
+jobs:
+  release-linux-amd64:
+    name: release linux/amd64
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        # build and publish in parallel: linux/386, linux/amd64, windows/386, windows/amd64, darwin/386, darwin/amd64
+        goos: [linux, windows, darwin]
+        goarch: ["386", amd64]
+    steps:
+      - uses: actions/checkout@v2
+      - uses: wangyoucao577/go-release-action@master
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          goos: ${{ matrix.goos }}
+          goarch: ${{ matrix.goarch }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,3 +18,4 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           goos: ${{ matrix.goos }}
           goarch: ${{ matrix.goarch }}
+          ldflags: -X github.com/cloudspannerecosystem/wrench/cmd.Version=${{ github.event.release.tag_name }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,6 +2,9 @@ on:
   release:
     types: [created]
 
+env:
+  CGO_ENABLED: 0
+
 jobs:
   release-linux-amd64:
     name: release linux/amd64
@@ -19,3 +22,4 @@ jobs:
           goos: ${{ matrix.goos }}
           goarch: ${{ matrix.goarch }}
           ldflags: -X github.com/cloudspannerecosystem/wrench/cmd.Version=${{ github.event.release.tag_name }}
+          build_flags: -tags netgo


### PR DESCRIPTION
You may find this automated matrix release build useful. Having prebuilt binaries to consume speeds up Docker builds significantly.

- Triggered on new Github Release creation.
- Binaries for each os/arch combination.
- Sets the cobra version to release tag name.