### PR TITLE
Support DML and Partitioned DML in migration files

### DIFF
--- a/pkg/spanner/client.go
+++ b/pkg/spanner/client.go
@@ -311,6 +311,13 @@ func (c *Client) ExecuteMigrations(ctx context.Context, migrations Migrations, l
 				}
 			}
 		case statementKindDML:
+			if _, err := c.ApplyDML(ctx, m.Statements); err != nil {
+				return &Error{
+					Code: ErrorCodeExecuteMigrations,
+					err:  err,
+				}
+			}
+		case statementKindPartitionedDML:
 			if _, err := c.ApplyPartitionedDML(ctx, m.Statements); err != nil {
 				return &Error{
 					Code: ErrorCodeExecuteMigrations,

--- a/pkg/spanner/migration.go
+++ b/pkg/spanner/migration.go
@@ -42,11 +42,12 @@ var (
 
 	MigrationNameRegex = regexp.MustCompile(`[a-zA-Z0-9_\-]+`)
 
-	dmlAnyRegex = regexp.MustCompile("^(UPDATE|DELETE|INSERT)[\t\n\f\r ].*")
+	dmlAnyRegex = regexp.MustCompile("(?i)^(UPDATE|DELETE|INSERT)[\t\n\f\r ].*")
 
-	// INSERT statements are not supported for partitioned DML. Although not every DML can be partitioned
-	// as it must be idempotent. This probably isn't solvable with more regexes.
-	notPartitionedDmlRegex = regexp.MustCompile("INSERT")
+	// Instead of a regex to determine if a DML statement is a PartitionedDML we check if it's
+	// not a PartitionedDML by checking for INSERT statements.
+	// An improvement would be to use spanners algo to distinguish between DML types.
+	notPartitionedDmlRegex = regexp.MustCompile(`(?i)^INSERT`)
 
 )
 

--- a/pkg/spanner/migration_test.go
+++ b/pkg/spanner/migration_test.go
@@ -17,17 +17,21 @@
 // IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 // CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-package spanner_test
+package spanner
 
 import (
 	"path/filepath"
 	"testing"
+)
 
-	"github.com/cloudspannerecosystem/wrench/pkg/spanner"
+const (
+	TestStmtDDL            = "ALTER TABLE Singers ADD COLUMN Foo STRING(MAX)"
+	TestStmtPartitionedDML = "UPDATE Singers SET FirstName = \"Bar\" WHERE SingerID = \"1\""
+	TestStmtDML            = "INSERT INTO Singers(FirstName) VALUES(\"Bar\")"
 )
 
 func TestLoadMigrations(t *testing.T) {
-	ms, err := spanner.LoadMigrations(filepath.Join("testdata", "migrations"))
+	ms, err := LoadMigrations(filepath.Join("testdata", "migrations"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -61,5 +65,105 @@ func TestLoadMigrations(t *testing.T) {
 		if ms[tc.idx].Name != tc.wantName {
 			t.Errorf("migrations[%d].name want %v, but got %v", tc.idx, tc.wantName, ms[tc.idx].Name)
 		}
+	}
+}
+
+func Test_getStatementKind(t *testing.T) {
+	tests := []struct {
+		name      string
+		statement string
+		want      statementKind
+	}{
+		{
+			"ALTER statement is DDL",
+			TestStmtDDL,
+			statementKindDDL,
+		},
+		{
+			"UPDATE statement is PartitionedDML",
+			TestStmtPartitionedDML,
+			statementKindPartitionedDML,
+		},
+		{
+			"INSERT statement is DML",
+			TestStmtDML,
+			statementKindDML,
+		},
+		{
+			"lowercase insert statement is DML",
+			TestStmtDML,
+			statementKindDML,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := getStatementKind(tt.statement); got != tt.want {
+				t.Errorf("getStatementKind() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_inspectStatementsKind(t *testing.T) {
+	tests := []struct {
+		name       string
+		statements []string
+		want       statementKind
+		wantErr    bool
+	}{
+		{
+			"Only DDL returns DDL",
+			[]string{TestStmtDDL, TestStmtDDL},
+			statementKindDDL,
+			false,
+		},
+		{
+			"Only PartitionedDML returns PartitionedDML",
+			[]string{TestStmtPartitionedDML, TestStmtPartitionedDML},
+			statementKindPartitionedDML,
+			false,
+		},
+		{
+			"Only DML returns DML",
+			[]string{TestStmtDML, TestStmtDML},
+			statementKindDDL,
+			false,
+		},
+		{
+			"DML and DDL returns error",
+			[]string{TestStmtDDL, TestStmtDML},
+			"",
+			true,
+		},
+		{
+			"DML and PartitionedDML returns error",
+			[]string{TestStmtDML, TestStmtPartitionedDML},
+			"",
+			true,
+		},
+		{
+			"DDL and PartitionedDML returns error",
+			[]string{TestStmtDDL, TestStmtPartitionedDML},
+			"",
+			true,
+		},
+		{
+			"no statements defaults to DDL as before",
+			[]string{},
+			statementKindDDL,
+			false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := inspectStatementsKind(tt.statements)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("inspectStatementsKind() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("inspectStatementsKind() got = %v, want %v", got, tt.want)
+			}
+		})
 	}
 }


### PR DESCRIPTION
Currently wrench only supports partitioned DML migration files. But this excludes INSERT statements which is useful for seeding databases with static data. This PR adds support for DML in separate migration files.

The current implementation extends the existing use of regexes but happy to discuss more robust approaches that better match what is supported by spanner.

Closes #35 