### PR TITLE
cmd: add delete subcommand to instance

### DIFF
--- a/cmd/instance.go
+++ b/cmd/instance.go
@@ -38,8 +38,36 @@ func instanceCreate(c *cobra.Command, _ []string) error {
 	return nil
 }
 
+var instanceDeleteCmd = &cobra.Command{
+	Use:   "delete",
+	Short: "Delete a instance",
+	Long:  "Delete a instance. This command will delete databases immediately and irrevocably disappear",
+	RunE:  instanceDelete,
+}
+
+func instanceDelete(c *cobra.Command, _ []string) error {
+	ctx := context.Background()
+
+	client, err := newSpannerAdminClient(ctx, c)
+	if err != nil {
+		return err
+	}
+	defer client.Close()
+
+	err = client.DeleteInstance(ctx, instance)
+	if err != nil {
+		return &Error{
+			err: err,
+			cmd: c,
+		}
+	}
+
+	return nil
+}
+
 func init() {
+	instanceCreateCmd.Flags().Int32Var(&node, flagNode, 1, "TODO: ")
 	instanceCmd.AddCommand(instanceCreateCmd)
 
-	instanceCmd.PersistentFlags().Int32Var(&node, flagNode, 1, "TODO: ")
+	instanceCmd.AddCommand(instanceDeleteCmd)
 }

--- a/pkg/spanner/admin.go
+++ b/pkg/spanner/admin.go
@@ -78,7 +78,7 @@ func (c *AdminClient) CreateInstance(ctx context.Context, node int32) error {
 
 func (c *AdminClient) DeleteInstance(ctx context.Context, nmae string) error {
 	req := &instancepb.DeleteInstanceRequest{
-		Name: fmt.Sprintf("projects/%s/instances/%s", c.Project, c.Instance),
+		Name: fmt.Sprintf("projects/%s/instances/%s", c.config.Project, c.config.Instance),
 	}
 
 	if err := c.spannerInstanceAdminClient.DeleteInstance(ctx, req); err != nil {

--- a/pkg/spanner/admin.go
+++ b/pkg/spanner/admin.go
@@ -75,3 +75,18 @@ func (c *AdminClient) CreateInstance(ctx context.Context, node int32) error {
 
 	return nil
 }
+
+func (c *AdminClient) DeleteInstance(ctx context.Context, nmae string) error {
+	req := &instancepb.DeleteInstanceRequest{
+		Name: fmt.Sprintf("projects/%s/instances/%s", c.Project, c.Instance),
+	}
+
+	if err := c.spannerInstanceAdminClient.DeleteInstance(ctx, req); err != nil {
+		return &Error{
+			Code: ErrorCodeDeleteInstance,
+			err:  fmt.Errorf("failed to delete instance: %w", err),
+		}
+	}
+
+	return nil
+}

--- a/pkg/spanner/errors.go
+++ b/pkg/spanner/errors.go
@@ -40,6 +40,7 @@ const (
 	ErrorCodeMigrationVersionDirty
 	ErrorCodeWaitOperation
 	ErrorCodeCreateInstance
+	ErrorCodeDeleteInstance
 )
 
 type Error struct {


### PR DESCRIPTION
## WHAT

Add `delete` subcommand to `instance` command.

## WHY

The wrench has been implemented `instance create` subcommand, add `delete` too.