### PR TITLE
Fix the missing "context" pacakge

### DIFF
--- a/cmd/instance.go
+++ b/cmd/instance.go
@@ -1,6 +1,8 @@
 package cmd
 
 import (
+	"context"
+
 	"github.com/spf13/cobra"
 )
 


### PR DESCRIPTION
## WHAT

fix build error by fixing the missing "context" package.

## WHY

- https://github.com/cloudspannerecosystem/wrench/pull/43 introduced a build error (the file is using `context` package but the package is not imported).
- Out projects are using the tool, and it has the error when we don't specify a version.
<img width="1400" alt="Screen Shot 2021-08-02 at 15 51 15" src="https://user-images.githubusercontent.com/6851886/127817446-927121e8-a419-4c59-9b73-067bf67aca08.png">