### PR TITLE
Raise error message when migration scripts have common version number

### DIFF
--- a/main.go
+++ b/main.go
@@ -45,7 +45,7 @@ func execute() {
 
 func handleError(err error) {
 	if err != nil {
-		fmt.Fprint(os.Stderr, (fmt.Sprintf("%s\n\t%s\n", err.Error(), errorDetails(err))))
+		fmt.Fprintf(os.Stderr, "%s\n\t%s\n", err.Error(), errorDetails(err))
 		os.Exit(1)
 	}
 }


### PR DESCRIPTION
## WHAT

This PR addresses the issue https://github.com/cloudspannerecosystem/wrench/issues/47.

The bug was that if more migration scripts have the same version number then, instead of reporting this as an issue, `wrench` pretended as if everything was OK and simply ignored the later migration scripts. 


## WHY

This bug caused me several hours of bug hunting. I hope with this PR, others will find their bug more easily.

Note: there was another minor issue reported by `golangci-lint` which I also fixed. 