### PR TITLE
pkg/spanner - breaking - remove migration tableName parameter from API

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -45,10 +45,11 @@ const (
 
 func newSpannerClient(ctx context.Context, c *cobra.Command) (*spanner.Client, error) {
 	config := &spanner.Config{
-		Project:         c.Flag(flagNameProject).Value.String(),
-		Instance:        c.Flag(flagNameInstance).Value.String(),
-		Database:        c.Flag(flagNameDatabase).Value.String(),
-		CredentialsFile: c.Flag(flagCredentialsFile).Value.String(),
+		Project:            c.Flag(flagNameProject).Value.String(),
+		Instance:           c.Flag(flagNameInstance).Value.String(),
+		Database:           c.Flag(flagNameDatabase).Value.String(),
+		CredentialsFile:    c.Flag(flagCredentialsFile).Value.String(),
+		MigrationTableName: "", // use pkg.spanner default
 	}
 
 	client, err := spanner.NewClient(ctx, config)

--- a/cmd/migrate.go
+++ b/cmd/migrate.go
@@ -33,7 +33,6 @@ import (
 
 const (
 	migrationsDirName  = "migrations"
-	migrationTableName = "SchemaMigrations"
 )
 
 // migrateCmd represents the migrate command
@@ -126,7 +125,7 @@ func migrateUp(c *cobra.Command, args []string) error {
 	}
 	defer client.Close()
 
-	if err = client.EnsureMigrationTable(ctx, migrationTableName); err != nil {
+	if err = client.EnsureMigrationTable(ctx); err != nil {
 		return &Error{
 			cmd: c,
 			err: err,
@@ -142,7 +141,7 @@ func migrateUp(c *cobra.Command, args []string) error {
 		}
 	}
 
-	return client.ExecuteMigrations(ctx, migrations, limit, migrationTableName)
+	return client.ExecuteMigrations(ctx, migrations, limit)
 }
 
 func migrateVersion(c *cobra.Command, args []string) error {
@@ -154,14 +153,14 @@ func migrateVersion(c *cobra.Command, args []string) error {
 	}
 	defer client.Close()
 
-	if err = client.EnsureMigrationTable(ctx, migrationTableName); err != nil {
+	if err = client.EnsureMigrationTable(ctx); err != nil {
 		return &Error{
 			cmd: c,
 			err: err,
 		}
 	}
 
-	v, _, err := client.GetSchemaMigrationVersion(ctx, migrationTableName)
+	v, _, err := client.GetSchemaMigrationVersion(ctx)
 	if err != nil {
 		var se *spanner.Error
 		if errors.As(err, &se) && se.Code == spanner.ErrorCodeNoMigration {
@@ -202,14 +201,14 @@ func migrateSet(c *cobra.Command, args []string) error {
 	}
 	defer client.Close()
 
-	if err = client.EnsureMigrationTable(ctx, migrationTableName); err != nil {
+	if err = client.EnsureMigrationTable(ctx); err != nil {
 		return &Error{
 			cmd: c,
 			err: err,
 		}
 	}
 
-	if err := client.SetSchemaMigrationVersion(ctx, uint(version), false, migrationTableName); err != nil {
+	if err := client.SetSchemaMigrationVersion(ctx, uint(version), false); err != nil {
 		return &Error{
 			cmd: c,
 			err: err,

--- a/pkg/spanner/config.go
+++ b/pkg/spanner/config.go
@@ -22,10 +22,11 @@ package spanner
 import "fmt"
 
 type Config struct {
-	Project         string
-	Instance        string
-	Database        string
-	CredentialsFile string
+	Project            string
+	Instance           string
+	Database           string
+	CredentialsFile    string
+	MigrationTableName string
 }
 
 func (c *Config) URL() string {


### PR DESCRIPTION
Refactor responsibility of setting the migration table name

Previously pkg/spanner Client API expected caller to explicitly
pass in the migration table name, except when doing a truncate
operation, where the migration table name was hardcoded and the
caller could not control it.

BEWARE: this commit introduces a breaking change to the Client
API and removes tableName. Instead, tableName can optionally
be set when a Client is created. See: pkg/spanner/config.go

Reworked cmd/ to use the new pkg/spanner API.


## WHAT

* rework pkg/spanner Client API not to require migration table name to be passed in each method call
* make it possible to configure migration table name through pkg/spanner Config

## WHY

see: https://github.com/cloudspannerecosystem/wrench/issues/50
