### PR TITLE
pkg/spanner: DDL/DML parsing error details

### DIFF
--- a/pkg/spanner/migration.go
+++ b/pkg/spanner/migration.go
@@ -115,7 +115,7 @@ func LoadMigrations(dir string) (Migrations, error) {
 		if err != nil {
 			nstatements, nerr := dmlToStatements(f.Name(), file)
 			if nerr != nil {
-				return nil, errors.New("failed to parse DDL/DML statements")
+				return nil, fmt.Errorf("failed to parse DDL/DML statements: %v, %v", err, nerr)
 			}
 			statements = nstatements
 		}


### PR DESCRIPTION
## WHAT

The change just adds a bit more verbosity to the error message so its
easier to find the cause of a problem.

## WHY

The error returned had very little context as to why a migration was not
able to be parsed.
