### PR TITLE
Add context timeout option

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -40,6 +40,7 @@ const (
 	flagPartitioned       = "partitioned"
 	flagPriority          = "priority"
 	flagNode              = "node"
+	flagTimeout           = "timeout"
 	defaultSchemaFileName = "schema.sql"
 )
 


### PR DESCRIPTION
<!--
Please read the contribution guidelines and the CLA carefully before
submitting your pull request.

https://cla.developers.google.com/
-->

## WHAT

Add option to set context timeout duration.
It is almost the same as the PR here, but I thought it would be better to be able to specify by option.
https://github.com/cloudspannerecosystem/wrench/pull/46

<!--
Write the change being made with this pull request
-->

## WHY

sometimes error would occur like this

```
Failed to execute the operation to Cloud Spanner, context deadline exceeded
```

As far as I can see this documents, the deadline of the context can be overwritten.
https://pkg.go.dev/cloud.google.com/go/spanner/admin/database/apiv1#hdr-Use_of_Context
https://pkg.go.dev/cloud.google.com/go#hdr-Timeouts_and_Cancellation

<!--
Write the motivation why you submit this pull request
-->

