### PR TITLE
use go 1.18 in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ version: 2
 jobs:
   build_and_test:
     docker:
-      - image: golang:1.16.2-buster
+      - image: golang:1.18-bullseye
 
     working_directory: /go/src/github.com/cloudspannerecosystem/wrench
 


### PR DESCRIPTION

## WHAT

Update go to 1.18 in CI.

## WHY
CI failed in master because of go.mod format change
