### PR TITLE
Add goreleaser github actions to upload binary artifacts

### DIFF
--- a/.github/workflows/goreleaser.yaml
+++ b/.github/workflows/goreleaser.yaml
@@ -1,0 +1,30 @@
+name: goreleaser
+
+on:
+  push:
+    tags:
+      - '*'
+
+env:
+  GO_VERSION: "~1.18"
+
+jobs:
+  goreleaser:
+    name: Release pre-build binary
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Set up Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: ${{ env.GO_VERSION }}
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v4
+        with:
+          version: latest
+          args: release --rm-dist
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
<!--
Please read the contribution guidelines and the CLA carefully before
submitting your pull request.

https://cla.developers.google.com/
-->

## WHAT

<!--
Write the change being made with this pull request
-->
SSIA

## WHY

<!--
Write the motivation why you submit this pull request
-->

The reason is to address this issue( https://github.com/cloudspannerecosystem/wrench/issues/67 ). The "goreleaser" GitHub actions workflow will be triggered and create the binary artifacts when the developers create tags. The target binary artifacts created by this workflow are below.

- darwin_amd64
- darwin_arm64
- linux_amd64
- linux_arm64
- linux_386

like this: {repository_name}_{tag_name}_{binary_type}.tar.gz
![Screen Shot 2022-12-21 at 8 05 12 PM](https://user-images.githubusercontent.com/499108/209053610-5b004892-b32d-48b3-8467-2fb66fd3de4c.png)
e.g.  https://github.com/nsega/wrench/releases/tag/v0.0.1

Also, once we unarchive this tar.gz, we can see these files.
- LICENSE
- README.md
- wrench (binary_file)
 

