### PR TITLE
add dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+FROM golang:1.18 as build
+
+ARG VERSION
+
+WORKDIR /go/src/app
+COPY . .
+
+RUN go mod download
+RUN CGO_ENABLED=0 go build \
+    -ldflags "-s -w -X github.com/cloudspannerecosystem/wrench/cmd.version=${VERSION}" \
+    -o /go/bin/app/wrench
+
+FROM gcr.io/distroless/static-debian11
+COPY --from=build /go/bin/app/wrench /
+ENTRYPOINT ["/wrench"]

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,8 @@ SPANNER_EMULATOR_HOST_REST := localhost:9020
 export SPANNER_PROJECT_ID ?= wrench-test-project
 export SPANNER_INSTANCE_ID ?= wrench-test-instance
 
+REGISTRY := mercari/wrench
+
 .PHONY: test
 test:
 	go test -race -v ./...
@@ -21,3 +23,6 @@ build:
 
 setup-emulator:
 	curl -s "${SPANNER_EMULATOR_HOST_REST}/v1/projects/${SPANNER_PROJECT_ID}/instances" --data '{"instanceId": "'${SPANNER_INSTANCE_ID}'"}'
+
+docker-build:
+	docker build . -t $(REGISTRY):$(VERSION) --build-arg VERSION=$(VERSION)


### PR DESCRIPTION

## WHAT

Add Dockerfile for building docker images

## WHY

We have used bazel to build a docker image for wrench before but we stop using bazel. So now there is no way to build a docker image.
