### PR TITLE
Add option.ClientOption for wrench configuration

### DIFF
--- a/pkg/spanner/client.go
+++ b/pkg/spanner/client.go
@@ -48,7 +48,13 @@ type Client struct {
 	spannerAdminClient *databasev1.DatabaseAdminClient
 }
 
-func NewClient(ctx context.Context, config *Config, opts ...option.ClientOption) (*Client, error) {
+func NewClient(ctx context.Context, config *Config) (*Client, error) {
+	var opts []option.ClientOption
+
+	// The options passed by config are evaluated first.
+	// Most options are last win so the options can be overridden by another option.
+	opts = append(opts, config.ClientOptions...)
+
 	if config.CredentialsFile != "" {
 		opts = append(opts, option.WithCredentialsFile(config.CredentialsFile))
 	}

--- a/pkg/spanner/config.go
+++ b/pkg/spanner/config.go
@@ -19,13 +19,24 @@
 
 package spanner
 
-import "fmt"
+import (
+	"fmt"
+
+	"google.golang.org/api/option"
+)
 
 type Config struct {
 	Project         string
 	Instance        string
 	Database        string
 	CredentialsFile string
+
+	// ClientOptions is options of Spanner clients when creating the clients for both normal
+	// and admin. This options are evaluated first and can be overridden by other
+	// configurations in Wrench.
+	//
+	// Experimental: There will be a breaking change in the future versions.
+	ClientOptions []option.ClientOption
 }
 
 func (c *Config) URL() string {


### PR DESCRIPTION
<!--
Please read the contribution guidelines and the CLA carefully before
submitting your pull request.

https://cla.developers.google.com/
-->

## WHAT

Add options.ClientOption as an option of wrench configuration.

Fixes https://github.com/cloudspannerecosystem/wrench/issues/59

## WHY

Support arbitrary options for Spanner clients.
