### PR TITLE
replaces ioutil to io

### DIFF
--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -23,9 +23,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
+
 	"github.com/cloudspannerecosystem/wrench/pkg/spanner"
 	"github.com/spf13/cobra"
-	"os"
 )
 
 var (

--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -20,13 +20,12 @@
 package cmd
 
 import (
+	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
-	"context"
-
 	"github.com/cloudspannerecosystem/wrench/pkg/spanner"
 	"github.com/spf13/cobra"
+	"os"
 )
 
 var (
@@ -57,7 +56,7 @@ func apply(c *cobra.Command, _ []string) error {
 			return errors.New("cannot specify DDL and DML at same time")
 		}
 
-		ddl, err := ioutil.ReadFile(ddlFile)
+		ddl, err := os.ReadFile(ddlFile)
 		if err != nil {
 			return &Error{
 				err: err,
@@ -81,7 +80,7 @@ func apply(c *cobra.Command, _ []string) error {
 	}
 
 	// apply dml
-	dml, err := ioutil.ReadFile(dmlFile)
+	dml, err := os.ReadFile(dmlFile)
 	if err != nil {
 		return &Error{
 			err: err,

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -21,8 +21,9 @@ package cmd
 
 import (
 	"context"
-	"github.com/spf13/cobra"
 	"os"
+
+	"github.com/spf13/cobra"
 )
 
 var createCmd = &cobra.Command{

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -21,9 +21,8 @@ package cmd
 
 import (
 	"context"
-	"io/ioutil"
-
 	"github.com/spf13/cobra"
+	"os"
 )
 
 var createCmd = &cobra.Command{
@@ -43,7 +42,7 @@ func create(c *cobra.Command, _ []string) error {
 	defer client.Close()
 
 	filename := schemaFilePath(c)
-	ddl, err := ioutil.ReadFile(filename)
+	ddl, err := os.ReadFile(filename)
 	if err != nil {
 		return &Error{
 			err: err,

--- a/cmd/load.go
+++ b/cmd/load.go
@@ -21,8 +21,9 @@ package cmd
 
 import (
 	"context"
-	"github.com/spf13/cobra"
 	"os"
+
+	"github.com/spf13/cobra"
 )
 
 var loadCmd = &cobra.Command{

--- a/cmd/load.go
+++ b/cmd/load.go
@@ -21,9 +21,8 @@ package cmd
 
 import (
 	"context"
-	"io/ioutil"
-
 	"github.com/spf13/cobra"
+	"os"
 )
 
 var loadCmd = &cobra.Command{
@@ -50,7 +49,7 @@ func load(c *cobra.Command, _ []string) error {
 		}
 	}
 
-	err = ioutil.WriteFile(schemaFilePath(c), ddl, 0o664)
+	err = os.WriteFile(schemaFilePath(c), ddl, 0o664)
 	if err != nil {
 		return &Error{
 			err: err,

--- a/pkg/spanner/client_test.go
+++ b/pkg/spanner/client_test.go
@@ -22,7 +22,6 @@ package spanner
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -74,7 +73,7 @@ func TestLoadDDL(t *testing.T) {
 		t.Fatalf("failed to load ddl: %v", err)
 	}
 
-	wantDDL, err := ioutil.ReadFile("testdata/schema.sql")
+	wantDDL, err := os.ReadFile("testdata/schema.sql")
 	if err != nil {
 		t.Fatalf("failed to read ddl file: %v", err)
 	}
@@ -88,7 +87,7 @@ func TestApplyDDLFile(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
 
-	ddl, err := ioutil.ReadFile("testdata/ddl.sql")
+	ddl, err := os.ReadFile("testdata/ddl.sql")
 	if err != nil {
 		t.Fatalf("failed to read ddl file: %v", err)
 	}
@@ -171,7 +170,7 @@ func TestApplyDMLFile(t *testing.T) {
 				t.Fatalf("failed to apply mutation: %v", err)
 			}
 
-			dml, err := ioutil.ReadFile("testdata/dml.sql")
+			dml, err := os.ReadFile("testdata/dml.sql")
 			if err != nil {
 				t.Fatalf("failed to read dml file: %v", err)
 			}
@@ -474,7 +473,7 @@ func testClientWithDatabase(t *testing.T, ctx context.Context) (*Client, func())
 		t.Fatalf("failed to create spanner client: %v", err)
 	}
 
-	ddl, err := ioutil.ReadFile("testdata/schema.sql")
+	ddl, err := os.ReadFile("testdata/schema.sql")
 	if err != nil {
 		t.Fatalf("failed to read schema file: %v", err)
 	}

--- a/pkg/spanner/migration.go
+++ b/pkg/spanner/migration.go
@@ -94,7 +94,9 @@ func LoadMigrations(dir string) (Migrations, error) {
 			continue
 		}
 
-		matches := migrationFileRegex.FindStringSubmatch(f.Name())
+		filename := f.Name()
+
+		matches := migrationFileRegex.FindStringSubmatch(filename)
 		if len(matches) != 4 {
 			continue
 		}
@@ -104,9 +106,7 @@ func LoadMigrations(dir string) (Migrations, error) {
 			continue
 		}
 
-		fileName := f.Name()
-
-		file, err := os.ReadFile(filepath.Join(dir, fileName))
+		file, err := os.ReadFile(filepath.Join(dir, filename))
 		if err != nil {
 			continue
 		}
@@ -133,9 +133,9 @@ func LoadMigrations(dir string) (Migrations, error) {
 		})
 
 		if prevFileName, ok := versions[version]; ok {
-			return nil, fmt.Errorf("colliding version number \"%d\" between file names \"%s\" and \"%s\"", version, prevFileName, fileName)
+			return nil, fmt.Errorf("colliding version number \"%d\" between file names \"%s\" and \"%s\"", version, prevFileName, filename)
 		}
-		versions[version] = fileName
+		versions[version] = filename
 	}
 
 	return migrations, nil

--- a/pkg/spanner/migration.go
+++ b/pkg/spanner/migration.go
@@ -22,7 +22,7 @@ package spanner
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"regexp"
 	"strconv"
@@ -80,7 +80,7 @@ func (ms Migrations) Less(i, j int) bool {
 }
 
 func LoadMigrations(dir string) (Migrations, error) {
-	files, err := ioutil.ReadDir(dir)
+	files, err := os.ReadDir(dir)
 	if err != nil {
 		return nil, err
 	}
@@ -106,7 +106,7 @@ func LoadMigrations(dir string) (Migrations, error) {
 
 		fileName := f.Name()
 
-		file, err := ioutil.ReadFile(filepath.Join(dir, fileName))
+		file, err := os.ReadFile(filepath.Join(dir, fileName))
 		if err != nil {
 			continue
 		}


### PR DESCRIPTION
## WHAT
This PR replaces ioutil usages.

## WHY
ioutil is deprecated from Golang 1.16.