### PR TITLE
👷 Implement CI that builds image and pushes to DockerHub

### DIFF
--- a/.github/workflows/publish-docker-release.yaml
+++ b/.github/workflows/publish-docker-release.yaml
@@ -1,0 +1,36 @@
+name: Publish Docker image on release
+
+on:
+  release:
+    types:
+      - released
+
+jobs:
+  release-docker:
+    name: Release Docker image
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Extract metadata for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            mercari/wrench
+          tags: |
+            type=semver,pattern={{version}}
+      - name: Login to DockerHub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ./Dockerfile
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            VERSION=${{ steps.meta.outputs.tags }}


### PR DESCRIPTION
I'm working at Merpay cashio team as an intern!
Feel free to contact me regarding this PR :)
(Slack name: `@Shion(Intern)` )

## WHAT
Implemented GitHub Actions that build images and push them to DockerHub.

## WHY
As it is discussed in #82 .

## Things to be concerned
In order to make this GitHub Actions works, you have to set `DOCKERHUB_USERNAME` `DOCKERHUB_TOKEN` .

You can validate this workflow with following references.
- https://github.com/docker/metadata-action#tags-input
- https://docs.github.com/en/actions/publishing-packages/publishing-docker-images