### PR TITLE
add --skip_change_stream flag to load command

### DIFF
--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     services:
       emulator:
-        image: gcr.io/cloud-spanner-emulator/emulator:1.5.0
+        image: gcr.io/cloud-spanner-emulator/emulator:1.5.14
         ports:
           - 9010:9010
           - 9020:9020

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -41,6 +41,7 @@ const (
 	flagPriority          = "priority"
 	flagNode              = "node"
 	flagTimeout           = "timeout"
+	flagSkipChangeStream  = "skip_change_stream"
 	defaultSchemaFileName = "schema.sql"
 )
 

--- a/cmd/load.go
+++ b/cmd/load.go
@@ -26,6 +26,9 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var (
+	skipChangeStream bool
+)
 var loadCmd = &cobra.Command{
 	Use:   "load",
 	Short: "Load schema from server to file",
@@ -42,7 +45,7 @@ func load(c *cobra.Command, _ []string) error {
 	}
 	defer client.Close()
 
-	ddl, err := client.LoadDDL(ctx)
+	ddl, err := client.LoadDDL(ctx, skipChangeStream)
 	if err != nil {
 		return &Error{
 			err: err,
@@ -59,4 +62,8 @@ func load(c *cobra.Command, _ []string) error {
 	}
 
 	return nil
+}
+
+func init() {
+	loadCmd.PersistentFlags().BoolVar(&skipChangeStream, flagSkipChangeStream, false, "Skip Change Stream to load")
 }

--- a/pkg/spanner/client_test.go
+++ b/pkg/spanner/client_test.go
@@ -59,6 +59,7 @@ const (
 	envSpannerInstanceID   = "SPANNER_INSTANCE_ID"
 	envSpannerDatabaseID   = "SPANNER_DATABASE_ID"
 	envSpannerEmulatorHost = "SPANNER_EMULATOR_HOST"
+	skipChangeStream       = false
 )
 
 func TestLoadDDL(t *testing.T) {
@@ -68,7 +69,8 @@ func TestLoadDDL(t *testing.T) {
 	client, done := testClientWithDatabase(t, ctx)
 	defer done()
 
-	gotDDL, err := client.LoadDDL(ctx)
+	// we can't include Change Stream schema to testdata because cloud-spanner-emulator hasn't supported it yet.
+	gotDDL, err := client.LoadDDL(ctx, skipChangeStream)
 	if err != nil {
 		t.Fatalf("failed to load ddl: %v", err)
 	}

--- a/pkg/spanner/testdata/schema.sql
+++ b/pkg/spanner/testdata/schema.sql
@@ -7,3 +7,5 @@ CREATE TABLE Singers (
   SingerID STRING(36) NOT NULL,
   FirstName STRING(1024),
 ) PRIMARY KEY(SingerID);
+
+CREATE CHANGE STREAM EverythingStream FOR ALL;


### PR DESCRIPTION
## WHAT
- add `--skip_change_stream` flag to `load` command

## WHY
- We use `load` command and its output `schema.sql` file for other tools.
- But some of these tools do not yet support Change Stream yet, and won't be supported for a while.
- So we would like to skip `CREATE CHANGE STREAM` DDL from output of `load` command.
