### PR TITLE
migrate: supports INSERT Statement

### DIFF
--- a/pkg/spanner/client.go
+++ b/pkg/spanner/client.go
@@ -361,6 +361,13 @@ func (c *Client) ExecuteMigrations(ctx context.Context, migrations Migrations, l
 				}
 			}
 		case statementKindDML:
+			if _, err := c.ApplyDML(ctx, m.Statements, PriorityTypeUnspecified); err != nil {
+				return &Error{
+					Code: ErrorCodeExecuteMigrations,
+					err:  err,
+				}
+			}
+		case statementKindPartitionedDML:
 			if _, err := c.ApplyPartitionedDML(ctx, m.Statements, PriorityTypeUnspecified); err != nil {
 				return &Error{
 					Code: ErrorCodeExecuteMigrations,

--- a/pkg/spanner/client_test.go
+++ b/pkg/spanner/client_test.go
@@ -237,13 +237,13 @@ func TestExecuteMigrations(t *testing.T) {
 		t.Fatalf("failed to execute migration: %v", err)
 	}
 
-	// ensure that 000003.sql and 000004.sql have been applied.
+	// ensure that 000003.sql, 000004.sql and 000005.sql have been applied.
 	ensureMigrationColumn(t, ctx, client, "LastName", "STRING(MAX)", "NO")
-	ensureMigrationVersionRecord(t, ctx, client, 4, false)
+	ensureMigrationVersionRecord(t, ctx, client, 5, false)
 
 	// ensure that schema is not changed and ExecuteMigrate is safely finished even though no migrations should be applied.
 	ensureMigrationColumn(t, ctx, client, "LastName", "STRING(MAX)", "NO")
-	ensureMigrationVersionRecord(t, ctx, client, 4, false)
+	ensureMigrationVersionRecord(t, ctx, client, 5, false)
 }
 
 func ensureMigrationColumn(t *testing.T, ctx context.Context, client *Client, columnName, spannerType, isNullable string) {

--- a/pkg/spanner/migration_test.go
+++ b/pkg/spanner/migration_test.go
@@ -32,7 +32,7 @@ func TestLoadMigrations(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if len(ms) != 3 {
+	if len(ms) != 4 {
 		t.Fatalf("migrations length want 3, but got %v", len(ms))
 	}
 

--- a/pkg/spanner/testdata/migrations/000005.sql
+++ b/pkg/spanner/testdata/migrations/000005.sql
@@ -1,0 +1,1 @@
+INSERT INTO Singers (SingerID, FirstName, LastName) VALUES ("2", "Hoge", "Fuga");


### PR DESCRIPTION
<!--
Please read the contribution guidelines and the CLA carefully before
submitting your pull request.

https://cla.developers.google.com/
-->

## WHAT

- support INSERT statement.

## WHY

- to support INSERT statement.
- Currently, Cloud Spanner does not support INSERT in partitioned DML (INSERT was treated as partitioned DML in wrench)
  - ref: https://cloud.google.com/spanner/docs/dml-partitioned#unsupported-features
