### PR TITLE
Change --rm-dist to --clean

### DIFF
--- a/.github/workflows/goreleaser.yaml
+++ b/.github/workflows/goreleaser.yaml
@@ -25,6 +25,6 @@ jobs:
         uses: goreleaser/goreleaser-action@v4
         with:
           version: latest
-          args: release --rm-dist
+          args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## WHAT

` --rm-dist` has been renamed to `--clean`. 

- [Ref](https://github.com/goreleaser/goreleaser/blob/700ff34236730335ae714a102687a99e60cc438a/www/docs/deprecations.md?plain=1#L450)

## WHY

<!--
Write the motivation why you submit this pull request
-->
