### PR TITLE
Update readme to suggest github container registry instead docker hub

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ CREATE TABLE Singers (
 ## Installation
 
 Get binary from [release page](https://github.com/cloudspannerecosystem/wrench/releases).
-Or, you can use Docker container: [mercari/wrench](https://hub.docker.com/r/mercari/wrench).
+Or, you can use [Docker image from packages.](https://github.com/cloudspannerecosystem/wrench/pkgs/container/wrench)
 
 ## Usage
 


### PR DESCRIPTION
<!--
Please read the contribution guidelines and the CLA carefully before
submitting your pull request.

https://cla.developers.google.com/
-->

## WHAT

SSIA

## WHY

Now, the docker container image in packages is available. https://github.com/cloudspannerecosystem/wrench/issues/116
Please suggest official one instead discontinued mercari/wrench in docker hub.
