### PR TITLE
Bump go version to 1.23

### DIFF
--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.21'
+          go-version: '1.23'
       - run: go version
       - run: make setup-emulator
       - name: make test with Cloud Spanner Emulator

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -6,7 +6,7 @@ on:
       - '*'
 
 env:
-  GO_VERSION: "~1.21"
+  GO_VERSION: "~1.23"
 
 jobs:
   goreleaser:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.21 as build
+FROM golang:1.23 as build
 
 ARG VERSION
 


### PR DESCRIPTION
<!--
Please read the contribution guidelines and the CLA carefully before
submitting your pull request.

https://cla.developers.google.com/
-->

## WHAT

<!--
Write the change being made with this pull request
-->
SSIA

## WHY

<!--
Write the motivation why you submit this pull request
-->
To fix [build error](https://github.com/cloudspannerecosystem/wrench/actions/runs/12346237915/job/34451523202).
go version in go.mod was updated to 1.23 in https://github.com/cloudspannerecosystem/wrench/pull/121.
We also need to update go version in Dockerfile and github actions.
