### PR TITLE
fix: skip empty DDL statements

### DIFF
--- a/pkg/spanner/memefish.go
+++ b/pkg/spanner/memefish.go
@@ -19,7 +19,9 @@ func toStatements(filename string, data []byte) ([]string, error) {
 		if err != nil {
 			return nil, err
 		}
-		result = append(result, stripped)
+		if len(stripped) != 0 {
+			result = append(result, stripped)
+		}
 	}
 	return result, nil
 }


### PR DESCRIPTION
## WHAT

Check empty DDL statements and skip them when loading

## WHY

Behavior was changed in a recent version which did not allow creating an empty database.
PR Migrate to memefish (#121) introduced the change
 
Fixes Issue #125