### PR TITLE
Set the MinOpened of the Spanner Client to 1

### DIFF
--- a/pkg/spanner/client.go
+++ b/pkg/spanner/client.go
@@ -59,7 +59,19 @@ func NewClient(ctx context.Context, config *Config) (*Client, error) {
 		opts = append(opts, option.WithCredentialsFile(config.CredentialsFile))
 	}
 
-	spannerClient, err := spanner.NewClient(ctx, config.URL(), opts...)
+	spannerClient, err := spanner.NewClientWithConfig(ctx, config.URL(),
+		spanner.ClientConfig{
+			SessionPoolConfig: spanner.SessionPoolConfig{
+				MaxOpened:                         spanner.DefaultSessionPoolConfig.MaxOpened,
+				MinOpened:                         1,
+				MaxIdle:                           spanner.DefaultSessionPoolConfig.MaxIdle,
+				HealthCheckWorkers:                spanner.DefaultSessionPoolConfig.HealthCheckWorkers,
+				HealthCheckInterval:               spanner.DefaultSessionPoolConfig.HealthCheckInterval,
+				TrackSessionHandles:               false,
+				InactiveTransactionRemovalOptions: spanner.DefaultSessionPoolConfig.InactiveTransactionRemovalOptions,
+			},
+		},
+		opts...)
 	if err != nil {
 		return nil, &Error{
 			Code: ErrorCodeCreateClient,


### PR DESCRIPTION
<!--
Please read the contribution guidelines and the CLA carefully before
submitting your pull request.

https://cla.developers.google.com/
-->

## WHAT

Set the MinOpened of the Spanner Client to 1.

<!--
Write the change being made with this pull request
-->

## WHY

Since the number of transactions executed by the Client created with wrench is usually small, I set MinOpened to 1.

There is no strict need to manage the number of sessions, so I don't think it's necessary to incorporate this PR.
If someone faces issues due to the default creation of 100 sessions, it might be sufficient to just consider it.

<!--
Write the motivation why you submit this pull request
-->
