### PR TITLE
Change to use gorelaser for build docker images

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -7,10 +7,13 @@ on:
 
 jobs:
   goreleaser:
-    name: Release pre-build binary
+    name: Release pre-build binary and docker images by goreleaser
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      packages: write
+    env:
+      REGISTRY: ghcr.io
     steps:
       - name: Checkout code
         uses: actions/checkout@v4.2.2
@@ -20,39 +23,19 @@ jobs:
         uses: actions/setup-go@v5.3.0
         with:
           go-version-file: ./go.mod
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3.4.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3.6.0
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3.10.0
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v6.2.1
         with:
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-  # https://docs.github.com/en/packages/managing-github-packages-using-github-actions-workflows/publishing-and-installing-a-package-with-github-actions#upgrading-a-workflow-that-accesses-a-registry-using-a-personal-access-token
-  build-and-push-ghcr:
-    name: Build and Push GHCR
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: write
-    env:
-      IMAGE_NAME: wrench
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4.2.2
-        with:
-          fetch-depth: 0
-      - name: Build image
-        run: docker build . --file Dockerfile --tag $IMAGE_NAME --label "runnumber=${GITHUB_RUN_ID}"
-      - name: Log in to registry
-        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
-      - name: Push image
-        run: |
-          IMAGE_ID=ghcr.io/${{ github.repository_owner }}/$IMAGE_NAME
-          IMAGE_ID=$(echo $IMAGE_ID | tr '[A-Z]' '[a-z]')
-          VERSION=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')
-          [[ "${{ github.ref }}" == "refs/tags/"* ]] && VERSION=$(echo $VERSION | sed -e 's/^v//')
-          [ "$VERSION" == "main" ] && VERSION=latest
-          echo IMAGE_ID=$IMAGE_ID
-          echo VERSION=$VERSION
-          docker tag $IMAGE_NAME $IMAGE_ID:$VERSION
-          docker push $IMAGE_ID:$VERSION

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -10,6 +10,10 @@ builds:
       - linux
       - windows
       - darwin
+    goarch:
+      - "386"
+      - amd64
+      - arm64
     ldflags:
       - -s -w -X github.com/cloudspannerecosystem/wrench/cmd.version={{.Version}}
     ignore:
@@ -32,3 +36,27 @@ changelog:
     exclude:
       - '^docs:'
       - '^test:'
+
+# https://goreleaser.com/customization/docker/
+dockers:
+- image_templates: ["ghcr.io/cloudspannerecosystem/{{ .ProjectName }}:{{ .Version }}-amd64"]
+  goarch: amd64
+  dockerfile: Dockerfile
+  use: buildx
+  build_flag_templates:
+  - --platform=linux/amd64
+- image_templates: ["ghcr.io/cloudspannerecosystem/{{ .ProjectName }}:{{ .Version }}-arm64v8"]
+  goarch: arm64
+  dockerfile: Dockerfile
+  use: buildx
+  build_flag_templates:
+  - --platform=linux/arm64/v8
+docker_manifests:
+- name_template: ghcr.io/cloudspannerecosystem/{{ .ProjectName }}:{{ .Version }}
+  image_templates:
+  - ghcr.io/cloudspannerecosystem/{{ .ProjectName }}:{{ .Version }}-amd64
+  - ghcr.io/cloudspannerecosystem/{{ .ProjectName }}:{{ .Version }}-arm64v8
+- name_template: ghcr.io/cloudspannerecosystem/{{ .ProjectName }}:latest
+  image_templates:
+  - ghcr.io/cloudspannerecosystem/{{ .ProjectName }}:{{ .Version }}-amd64
+  - ghcr.io/cloudspannerecosystem/{{ .ProjectName }}:{{ .Version }}-arm64v8

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,6 @@
-FROM golang:1.24 as build
-
-ARG VERSION
-
-WORKDIR /go/src/app
-COPY . .
-
-RUN go mod download
-RUN CGO_ENABLED=0 go build \
-    -ldflags "-s -w -X github.com/cloudspannerecosystem/wrench/cmd.version=${VERSION}" \
-    -o /go/bin/app/wrench
-
 FROM gcr.io/distroless/static-debian12
-COPY --from=build /go/bin/app/wrench /
+
+# The binary is built by goreleaser
+COPY wrench /
+
 ENTRYPOINT ["/wrench"]

--- a/Makefile
+++ b/Makefile
@@ -6,8 +6,6 @@ SPANNER_EMULATOR_HOST_REST := localhost:9020
 export SPANNER_PROJECT_ID ?= wrench-test-project
 export SPANNER_INSTANCE_ID ?= wrench-test-instance
 
-REGISTRY := ghcr.io/cloudspannerecosystem/wrench
-
 .PHONY: test
 test:
 	go test -race -v ./...
@@ -23,6 +21,3 @@ build:
 
 setup-emulator:
 	curl -s "${SPANNER_EMULATOR_HOST_REST}/v1/projects/${SPANNER_PROJECT_ID}/instances" --data '{"instanceId": "'${SPANNER_INSTANCE_ID}'"}'
-
-docker-build:
-	docker build . -t $(REGISTRY):$(VERSION) --build-arg VERSION=$(VERSION)


### PR DESCRIPTION
<!--
Please read the contribution guidelines and the CLA carefully before
submitting your pull request.

https://cla.developers.google.com/
-->

## WHAT

- Support multi platforms docker image building by goreleaser.
    - So far, this PR builds amd64 and arm64 images.
- Simplifiy `Dockerfile`
    - In gorelease's docker built, it seems just copy the binary instead of building application inside of container.
    - This changes breaks local development with Dockerfile.
        - For this reason, this PR deletes docker-build task in Makefile.

You can find build log and docker images in forked repo.

- https://github.com/sters/wrench/actions/runs/14724917630/job/41325422555
- https://github.com/sters/wrench/pkgs/container/wrench/404651925?tag=0.0.7

Another idea is keep Dockerfile as is and using docker's github action workflow to build multi platform images. [ref](https://docs.docker.com/build/ci/github-actions/multi-platform/#distribute-build-across-multiple-runners)
Once I tried it but build time is longer, need to consider cache strategies, and it will be a bit complicated workflow and Dockerfile.
In order to solve the problem simply, I propose with this PR to use goreleaser to release binary and images.

## WHY

To solve #119 
