### PR TITLE
Fix required argument handling

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -22,6 +22,7 @@ package cmd
 import (
 	"context"
 	"io/fs"
+	"log"
 	"os"
 	"runtime/debug"
 	"time"
@@ -59,11 +60,6 @@ var rootCmd = &cobra.Command{
 			ctx = wrenchfs.WithContext(ctx, CustomFileSystemFunc())
 			cmd.SetContext(ctx)
 		}
-		if CustomFileSystemFunc == nil {
-			if err := cobra.MarkFlagRequired(cmd.PersistentFlags(), flagNameDirectory); err != nil {
-				panic(err)
-			}
-		}
 		return nil
 	},
 }
@@ -97,6 +93,12 @@ func init() {
 
 	rootCmd.Version = versionInfo()
 	rootCmd.SetVersionTemplate(versionTemplate)
+
+	if CustomFileSystemFunc == nil {
+		if err := cobra.MarkFlagRequired(rootCmd.PersistentFlags(), flagNameDirectory); err != nil {
+			log.Fatal(err)
+		}
+	}
 }
 
 func spannerProjectID() string {


### PR DESCRIPTION
<!--
Please read the contribution guidelines and the CLA carefully before
submitting your pull request.

https://cla.developers.google.com/
-->

## WHAT
fix new bug from #137

## WHY

I got an error on execution with sub-command

```
panic: no such flag -directory

goroutine 1 [running]:
github.com/cloudspannerecosystem/wrench/cmd.init.func1(0xc0000eb100?, {0x153f613?, 0x4?, 0x153f547?})
	/home/runner/go/pkg/mod/github.com/cloudspannerecosystem/wrench@v1.11.5/cmd/root.go:64 +0x125
github.com/spf13/cobra.(*Command).execute(0x2345560, {0xc00048f1c0, 0x4, 0x4})
	/home/runner/go/pkg/mod/github.com/spf13/cobra@v1.9.1/command.go:986 +0x923
```
