### PR TITLE
Fix bug: use os.ReadFile/ReadDir instead of os.DirFS for support absolute path

### DIFF
--- a/internal/fs/fs.go
+++ b/internal/fs/fs.go
@@ -17,15 +17,19 @@ func FromContext(ctx context.Context) fs.FS {
 	if ok && fsys != nil {
 		return fsys
 	}
-	return os.DirFS(".")
+	return nil
 }
 
 func ReadFile(ctx context.Context, path string) ([]byte, error) {
-	fsys := FromContext(ctx)
-	return fs.ReadFile(fsys, path)
+	if fsys := FromContext(ctx); fsys != nil {
+		return fs.ReadFile(fsys, path)
+	}
+	return os.ReadFile(path)
 }
 
 func ReadDir(ctx context.Context, path string) ([]fs.DirEntry, error) {
-	fsys := FromContext(ctx)
-	return fs.ReadDir(fsys, path)
+	if fsys := FromContext(ctx); fsys != nil {
+		return fs.ReadDir(fsys, path)
+	}
+	return os.ReadDir(path)
 }


### PR DESCRIPTION
<!--
Please read the contribution guidelines and the CLA carefully before
submitting your pull request.

https://cla.developers.google.com/
-->

## WHAT

SSIA
this bug was happens after v0.11.5.
This is a PR to align the behavior with v0.11.4 or earlier.

## WHY

We got an error with absolute path like below
```
Error command: up, version: 1.11.7
	Invalid file path, readdir /spanner/migrations: invalid argument
```

Because `os.DirFS` doesn't support this kind of absolute path to each functions arguments.
