### PR TITLE
support migration with proto descriptors file

### DIFF
--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -23,6 +23,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"path/filepath"
 	"github.com/cloudspannerecosystem/wrench/internal/fs"
 	"github.com/cloudspannerecosystem/wrench/pkg/spanner"
 	"github.com/spf13/cobra"
@@ -149,4 +150,5 @@ func init() {
 	applyCmd.PersistentFlags().StringVar(&dmlFile, flagDMLFile, "", "DML file to be applied")
 	applyCmd.PersistentFlags().BoolVar(&partitioned, flagPartitioned, false, "Whether given DML should be executed as a Partitioned-DML or not")
 	applyCmd.PersistentFlags().StringVar(&priority, flagPriority, "", "The priority to apply DML(optional)")
+	applyCmd.PersistentFlags().String(flagProtoDescriptorFile, "", "Proto descriptor file to be used with DDL operations")
 }

--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -23,7 +23,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"path/filepath"
 	"github.com/cloudspannerecosystem/wrench/internal/fs"
 	"github.com/cloudspannerecosystem/wrench/pkg/spanner"
 	"github.com/spf13/cobra"

--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -64,7 +64,19 @@ func apply(c *cobra.Command, _ []string) error {
 			}
 		}
 
-		err = client.ApplyDDLFile(ctx, ddlFile, ddl)
+		var protoDescriptor []byte
+		protoDescriptorFile := protoDescriptorFilePath(c)
+		if protoDescriptorFile != "" {
+			protoDescriptor, err = fs.ReadFile(ctx, protoDescriptorFile)
+			if err != nil {
+				return &Error{
+					err: err,
+					cmd: c,
+				}
+			}
+		}
+
+		err = client.ApplyDDLFile(ctx, ddlFile, ddl, protoDescriptor)
 		if err != nil {
 			return &Error{
 				err: err,

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -41,6 +41,7 @@ const (
 	flagPriority          = "priority"
 	flagNode              = "node"
 	flagTimeout           = "timeout"
+	flagProtoDescriptorFile = "proto_descriptor_file"
 	defaultSchemaFileName = "schema.sql"
 )
 
@@ -86,6 +87,14 @@ func schemaFilePath(c *cobra.Command) string {
 	filename := c.Flag(flagNameSchemaFile).Value.String()
 	if filename == "" {
 		filename = defaultSchemaFileName
+	}
+	return filepath.Join(c.Flag(flagNameDirectory).Value.String(), filename)
+}
+
+func protoDescriptorFilePath(c *cobra.Command) string {
+	filename := c.Flag(flagProtoDescriptorFile).Value.String()
+	if filename == "" {
+		return ""
 	}
 	return filepath.Join(c.Flag(flagNameDirectory).Value.String(), filename)
 }

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -29,20 +29,20 @@ import (
 )
 
 const (
-	flagNameProject       = "project"
-	flagNameInstance      = "instance"
-	flagNameDatabase      = "database"
-	flagNameDirectory     = "directory"
-	flagCredentialsFile   = "credentials_file"
-	flagNameSchemaFile    = "schema_file"
-	flagDDLFile           = "ddl"
-	flagDMLFile           = "dml"
-	flagPartitioned       = "partitioned"
-	flagPriority          = "priority"
-	flagNode              = "node"
-	flagTimeout           = "timeout"
+	flagNameProject         = "project"
+	flagNameInstance        = "instance"
+	flagNameDatabase        = "database"
+	flagNameDirectory       = "directory"
+	flagCredentialsFile     = "credentials_file"
+	flagNameSchemaFile      = "schema_file"
+	flagDDLFile             = "ddl"
+	flagDMLFile             = "dml"
+	flagPartitioned         = "partitioned"
+	flagPriority            = "priority"
+	flagNode                = "node"
+	flagTimeout             = "timeout"
 	flagProtoDescriptorFile = "proto_descriptor_file"
-	defaultSchemaFileName = "schema.sql"
+	defaultSchemaFileName   = "schema.sql"
 )
 
 func newSpannerClient(ctx context.Context, c *cobra.Command) (*spanner.Client, error) {
@@ -93,12 +93,12 @@ func schemaFilePath(c *cobra.Command) string {
 
 func protoDescriptorFilePath(c *cobra.Command) string {
 	var filename string
-	
+
 	// Try to get the flag value from the specific command
 	if flag := c.Flag(flagProtoDescriptorFile); flag != nil {
 		filename = flag.Value.String()
 	}
-	
+
 	if filename == "" {
 		return ""
 	}

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -92,9 +92,16 @@ func schemaFilePath(c *cobra.Command) string {
 }
 
 func protoDescriptorFilePath(c *cobra.Command) string {
-	filename := c.Flag(flagProtoDescriptorFile).Value.String()
+	var filename string
+	
+	// Try to get the flag value from the specific command
+	if flag := c.Flag(flagProtoDescriptorFile); flag != nil {
+		filename = flag.Value.String()
+	}
+	
 	if filename == "" {
 		return ""
 	}
+
 	return filepath.Join(c.Flag(flagNameDirectory).Value.String(), filename)
 }

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -50,7 +50,19 @@ func create(c *cobra.Command, _ []string) error {
 		}
 	}
 
-	err = client.CreateDatabase(ctx, filename, ddl)
+		var protoDescriptor []byte
+		protoDescriptorFile := protoDescriptorFilePath(c)
+		if protoDescriptorFile != "" {
+			protoDescriptor, err = fs.ReadFile(ctx, protoDescriptorFile)
+			if err != nil {
+				return &Error{
+					err: err,
+					cmd: c,
+				}
+			}
+		}
+
+	err = client.CreateDatabase(ctx, filename, ddl, protoDescriptor)
 	if err != nil {
 		return &Error{
 			err: err,

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -21,11 +21,9 @@ package cmd
 
 import (
 	"context"
-	"path/filepath"
 	"github.com/cloudspannerecosystem/wrench/internal/fs"
 	"github.com/spf13/cobra"
 )
-
 
 var createCmd = &cobra.Command{
 	Use:   "create",
@@ -52,17 +50,17 @@ func create(c *cobra.Command, _ []string) error {
 		}
 	}
 
-		var protoDescriptor []byte
-		protoDescriptorFile := protoDescriptorFilePath(c)
-		if protoDescriptorFile != "" {
-			protoDescriptor, err = fs.ReadFile(ctx, protoDescriptorFile)
-			if err != nil {
-				return &Error{
-					err: err,
-					cmd: c,
-				}
+	var protoDescriptor []byte
+	protoDescriptorFile := protoDescriptorFilePath(c)
+	if protoDescriptorFile != "" {
+		protoDescriptor, err = fs.ReadFile(ctx, protoDescriptorFile)
+		if err != nil {
+			return &Error{
+				err: err,
+				cmd: c,
 			}
 		}
+	}
 
 	err = client.CreateDatabase(ctx, filename, ddl, protoDescriptor)
 	if err != nil {

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -21,9 +21,11 @@ package cmd
 
 import (
 	"context"
+	"path/filepath"
 	"github.com/cloudspannerecosystem/wrench/internal/fs"
 	"github.com/spf13/cobra"
 )
+
 
 var createCmd = &cobra.Command{
 	Use:   "create",
@@ -71,4 +73,8 @@ func create(c *cobra.Command, _ []string) error {
 	}
 
 	return nil
+}
+
+func init() {
+	createCmd.Flags().String(flagProtoDescriptorFile, "", "Proto descriptor file to be used with database creation")
 }

--- a/cmd/load.go
+++ b/cmd/load.go
@@ -22,11 +22,9 @@ package cmd
 import (
 	"context"
 	"os"
-	"path/filepath"
 
 	"github.com/spf13/cobra"
 )
-
 
 var loadCmd = &cobra.Command{
 	Use:   "load",

--- a/cmd/load.go
+++ b/cmd/load.go
@@ -42,7 +42,7 @@ func load(c *cobra.Command, _ []string) error {
 	}
 	defer client.Close()
 
-	ddl, err := client.LoadDDL(ctx)
+	ddl, protoDescriptors, err := client.LoadDDL(ctx)
 	if err != nil {
 		return &Error{
 			err: err,
@@ -55,6 +55,17 @@ func load(c *cobra.Command, _ []string) error {
 		return &Error{
 			err: err,
 			cmd: c,
+		}
+	}
+
+	protoDescriptorFile := protoDescriptorFilePath(c)
+	if protoDescriptorFile != "" && len(protoDescriptors) > 0 {
+		err = os.WriteFile(protoDescriptorFile, protoDescriptors, 0o664)
+		if err != nil {
+			return &Error{
+				err: err,
+				cmd: c,
+			}
 		}
 	}
 

--- a/cmd/load.go
+++ b/cmd/load.go
@@ -22,9 +22,11 @@ package cmd
 import (
 	"context"
 	"os"
+	"path/filepath"
 
 	"github.com/spf13/cobra"
 )
+
 
 var loadCmd = &cobra.Command{
 	Use:   "load",
@@ -70,4 +72,8 @@ func load(c *cobra.Command, _ []string) error {
 	}
 
 	return nil
+}
+
+func init() {
+	loadCmd.Flags().String(flagProtoDescriptorFile, "", "Proto descriptor file name for output. If specified and proto descriptors exist, they will be written to this file")
 }

--- a/cmd/migrate.go
+++ b/cmd/migrate.go
@@ -38,7 +38,6 @@ const (
 	migrationTableName = "SchemaMigrations"
 )
 
-
 // migrateCmd represents the migrate command
 var migrateCmd = &cobra.Command{
 	Use:   "migrate",

--- a/cmd/migrate.go
+++ b/cmd/migrate.go
@@ -38,6 +38,7 @@ const (
 	migrationTableName = "SchemaMigrations"
 )
 
+
 // migrateCmd represents the migrate command
 var migrateCmd = &cobra.Command{
 	Use:   "migrate",
@@ -65,6 +66,8 @@ func init() {
 		Short: "Set version V but don't run migration (ignores dirty state)",
 		RunE:  migrateSet,
 	}
+
+	migrateUpCmd.Flags().String(flagProtoDescriptorFile, "", "Proto descriptor file to be used with migrations")
 
 	migrateCmd.AddCommand(
 		migrateCreateCmd,

--- a/cmd/migrate.go
+++ b/cmd/migrate.go
@@ -28,6 +28,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/cloudspannerecosystem/wrench/internal/fs"
 	"github.com/cloudspannerecosystem/wrench/pkg/spanner"
 	"github.com/spf13/cobra"
 )
@@ -144,7 +145,19 @@ func migrateUp(c *cobra.Command, args []string) error {
 		}
 	}
 
-	return client.ExecuteMigrations(ctx, migrations, limit, migrationTableName)
+	var protoDescriptor []byte
+	protoDescriptorFile := protoDescriptorFilePath(c)
+	if protoDescriptorFile != "" {
+		protoDescriptor, err = fs.ReadFile(ctx, protoDescriptorFile)
+		if err != nil {
+			return &Error{
+				err: err,
+				cmd: c,
+			}
+		}
+	}
+
+	return client.ExecuteMigrations(ctx, migrations, limit, migrationTableName, protoDescriptor)
 }
 
 func migrateVersion(c *cobra.Command, _ []string) error {

--- a/pkg/spanner/client.go
+++ b/pkg/spanner/client.go
@@ -105,9 +105,9 @@ func (c *Client) CreateDatabase(ctx context.Context, filename string, ddl []byte
 	}
 
 	createReq := &databasepb.CreateDatabaseRequest{
-		Parent:          fmt.Sprintf("projects/%s/instances/%s", c.config.Project, c.config.Instance),
-		CreateStatement: fmt.Sprintf("CREATE DATABASE `%s`", c.config.Database),
-		ExtraStatements: statements,
+		Parent:           fmt.Sprintf("projects/%s/instances/%s", c.config.Project, c.config.Instance),
+		CreateStatement:  fmt.Sprintf("CREATE DATABASE `%s`", c.config.Database),
+		ExtraStatements:  statements,
 		ProtoDescriptors: protoDescriptors,
 	}
 
@@ -224,8 +224,8 @@ func (c *Client) ApplyDDLFile(ctx context.Context, filename string, ddl []byte, 
 
 func (c *Client) ApplyDDL(ctx context.Context, statements []string, protoDescriptors []byte) error {
 	req := &databasepb.UpdateDatabaseDdlRequest{
-		Database:   c.config.URL(),
-		Statements: statements,
+		Database:         c.config.URL(),
+		Statements:       statements,
 		ProtoDescriptors: protoDescriptors,
 	}
 

--- a/pkg/spanner/client.go
+++ b/pkg/spanner/client.go
@@ -187,12 +187,12 @@ func (c *Client) TruncateAllTables(ctx context.Context) error {
 	return nil
 }
 
-func (c *Client) LoadDDL(ctx context.Context) ([]byte, error) {
+func (c *Client) LoadDDL(ctx context.Context) ([]byte, []byte, error) {
 	req := &databasepb.GetDatabaseDdlRequest{Database: c.config.URL()}
 
 	res, err := c.spannerAdminClient.GetDatabaseDdl(ctx, req)
 	if err != nil {
-		return nil, &Error{
+		return nil, nil, &Error{
 			Code: ErrorCodeLoadSchema,
 			err:  err,
 		}
@@ -210,7 +210,7 @@ func (c *Client) LoadDDL(ctx context.Context) ([]byte, error) {
 		schema = append(schema[:], []byte(statement)[:]...)
 	}
 
-	return schema, nil
+	return schema, res.ProtoDescriptors, nil
 }
 
 func (c *Client) ApplyDDLFile(ctx context.Context, filename string, ddl []byte, protoDescriptors []byte) error {

--- a/pkg/spanner/client_test.go
+++ b/pkg/spanner/client_test.go
@@ -68,7 +68,7 @@ func TestLoadDDL(t *testing.T) {
 	client, done := testClientWithDatabase(t, ctx)
 	defer done()
 
-	gotDDL, err := client.LoadDDL(ctx)
+	gotDDL, gotProtoDescriptors, err := client.LoadDDL(ctx)
 	if err != nil {
 		t.Fatalf("failed to load ddl: %v", err)
 	}
@@ -81,49 +81,69 @@ func TestLoadDDL(t *testing.T) {
 	if want, got := string(wantDDL), string(gotDDL); want != got {
 		t.Errorf("want: \n%s\n but got: \n%s", want, got)
 	}
+
+	// Proto descriptors should be empty for a basic schema
+	if gotProtoDescriptors != nil && len(gotProtoDescriptors) > 0 {
+		t.Errorf("expected empty proto descriptors for basic schema, got %d bytes", len(gotProtoDescriptors))
+	}
 }
 
 func TestApplyDDLFile(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
 
-	ddl, err := os.ReadFile("testdata/ddl.sql")
-	if err != nil {
-		t.Fatalf("failed to read ddl file: %v", err)
-	}
-
-	client, done := testClientWithDatabase(t, ctx)
-	defer done()
-
-	if err := client.ApplyDDLFile(ctx, "testdata/ddl.sql", ddl); err != nil {
-		t.Fatalf("failed to apply ddl file: %v", err)
-	}
-
-	ri := client.spannerClient.Single().Query(ctx, spanner.Statement{
-		SQL: "SELECT column_name, spanner_type FROM information_schema.columns WHERE table_catalog = '' AND table_name = @table AND column_name = @column",
-		Params: map[string]interface{}{
-			"table":  singerTable,
-			"column": "Foo",
+	tests := map[string]struct {
+		protoDescriptors []byte
+	}{
+		"without proto descriptors": {
+			protoDescriptors: nil,
 		},
-	})
-	defer ri.Stop()
-
-	row, err := ri.Next()
-	if err == iterator.Done {
-		t.Fatalf("failed to get table information: %v", err)
+		"with empty proto descriptors": {
+			protoDescriptors: []byte{},
+		},
 	}
 
-	c := &column{}
-	if err := row.ToStruct(c); err != nil {
-		t.Fatalf("failed to convert row to struct: %v", err)
-	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			ddl, err := os.ReadFile("testdata/ddl.sql")
+			if err != nil {
+				t.Fatalf("failed to read ddl file: %v", err)
+			}
 
-	if want, got := "Foo", c.ColumnName; want != got {
-		t.Errorf("want %s, but got %s", want, got)
-	}
+			client, done := testClientWithDatabase(t, ctx)
+			defer done()
 
-	if want, got := "STRING(MAX)", c.SpannerType; want != got {
-		t.Errorf("want %s, but got %s", want, got)
+			if err := client.ApplyDDLFile(ctx, "testdata/ddl.sql", ddl, test.protoDescriptors); err != nil {
+				t.Fatalf("failed to apply ddl file: %v", err)
+			}
+
+			ri := client.spannerClient.Single().Query(ctx, spanner.Statement{
+				SQL: "SELECT column_name, spanner_type FROM information_schema.columns WHERE table_catalog = '' AND table_name = @table AND column_name = @column",
+				Params: map[string]interface{}{
+					"table":  singerTable,
+					"column": "Foo",
+				},
+			})
+			defer ri.Stop()
+
+			row, err := ri.Next()
+			if err == iterator.Done {
+				t.Fatalf("failed to get table information: %v", err)
+			}
+
+			c := &column{}
+			if err := row.ToStruct(c); err != nil {
+				t.Fatalf("failed to convert row to struct: %v", err)
+			}
+
+			if want, got := "Foo", c.ColumnName; want != got {
+				t.Errorf("want %s, but got %s", want, got)
+			}
+
+			if want, got := "STRING(MAX)", c.SpannerType; want != got {
+				t.Errorf("want %s, but got %s", want, got)
+			}
+		})
 	}
 }
 
@@ -205,45 +225,60 @@ func TestExecuteMigrations(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
 
-	client, done := testClientWithDatabase(t, ctx)
-	defer done()
-
-	// to ensure partitioned-dml (000003.sql) will be applied correctly, insert a row before migration.
-	_, err := client.spannerClient.Apply(
-		ctx,
-		[]*spanner.Mutation{
-			spanner.Insert(singerTable, []string{"SingerID", "FirstName"}, []interface{}{"1", "foo"}),
+	tests := map[string]struct {
+		protoDescriptors []byte
+	}{
+		"without proto descriptors": {
+			protoDescriptors: nil,
 		},
-	)
-	if err != nil {
-		t.Fatalf("failed to apply mutation: %v", err)
+		"with empty proto descriptors": {
+			protoDescriptors: []byte{},
+		},
 	}
 
-	migrations, err := ReadMigrations(ctx, "testdata/migrations")
-	if err != nil {
-		t.Fatalf("failed to load migrations: %v", err)
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			client, done := testClientWithDatabase(t, ctx)
+			defer done()
+
+			// to ensure partitioned-dml (000003.sql) will be applied correctly, insert a row before migration.
+			_, err := client.spannerClient.Apply(
+				ctx,
+				[]*spanner.Mutation{
+					spanner.Insert(singerTable, []string{"SingerID", "FirstName"}, []interface{}{"1", "foo"}),
+				},
+			)
+			if err != nil {
+				t.Fatalf("failed to apply mutation: %v", err)
+			}
+
+			migrations, err := ReadMigrations(ctx, "testdata/migrations")
+			if err != nil {
+				t.Fatalf("failed to load migrations: %v", err)
+			}
+
+			// only apply 000002.sql by specifying limit 1.
+			if err := client.ExecuteMigrations(ctx, migrations, 1, migrationTable, test.protoDescriptors); err != nil {
+				t.Fatalf("failed to execute migration: %v", err)
+			}
+
+			// ensure that only 000002.sql has been applied.
+			ensureMigrationColumn(t, ctx, client, "LastName", "STRING(MAX)", "YES")
+			ensureMigrationVersionRecord(t, ctx, client, 2, false)
+
+			if err := client.ExecuteMigrations(ctx, migrations, len(migrations), migrationTable, test.protoDescriptors); err != nil {
+				t.Fatalf("failed to execute migration: %v", err)
+			}
+
+			// ensure that 000003.sql, 000004.sql and 000005.sql have been applied.
+			ensureMigrationColumn(t, ctx, client, "LastName", "STRING(MAX)", "NO")
+			ensureMigrationVersionRecord(t, ctx, client, 5, false)
+
+			// ensure that schema is not changed and ExecuteMigrate is safely finished even though no migrations should be applied.
+			ensureMigrationColumn(t, ctx, client, "LastName", "STRING(MAX)", "NO")
+			ensureMigrationVersionRecord(t, ctx, client, 5, false)
+		})
 	}
-
-	// only apply 000002.sql by specifying limit 1.
-	if err := client.ExecuteMigrations(ctx, migrations, 1, migrationTable); err != nil {
-		t.Fatalf("failed to execute migration: %v", err)
-	}
-
-	// ensure that only 000002.sql has been applied.
-	ensureMigrationColumn(t, ctx, client, "LastName", "STRING(MAX)", "YES")
-	ensureMigrationVersionRecord(t, ctx, client, 2, false)
-
-	if err := client.ExecuteMigrations(ctx, migrations, len(migrations), migrationTable); err != nil {
-		t.Fatalf("failed to execute migration: %v", err)
-	}
-
-	// ensure that 000003.sql, 000004.sql and 000005.sql have been applied.
-	ensureMigrationColumn(t, ctx, client, "LastName", "STRING(MAX)", "NO")
-	ensureMigrationVersionRecord(t, ctx, client, 5, false)
-
-	// ensure that schema is not changed and ExecuteMigrate is safely finished even though no migrations should be applied.
-	ensureMigrationColumn(t, ctx, client, "LastName", "STRING(MAX)", "NO")
-	ensureMigrationVersionRecord(t, ctx, client, 5, false)
 }
 
 func ensureMigrationColumn(t *testing.T, ctx context.Context, client *Client, columnName, spannerType, isNullable string) {
@@ -441,6 +476,97 @@ func TestPriorityPBOf(t *testing.T) {
 	}
 }
 
+func TestCreateDatabase(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	tests := map[string]struct {
+		protoDescriptors []byte
+	}{
+		"without proto descriptors": {
+			protoDescriptors: nil,
+		},
+		"with empty proto descriptors": {
+			protoDescriptors: []byte{},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			if v := os.Getenv(envSpannerEmulatorHost); v == "" {
+				t.Fatal("test must use spanner emulator")
+			}
+
+			project := os.Getenv(envSpannerProjectID)
+			if project == "" {
+				t.Fatalf("must set %s", envSpannerProjectID)
+			}
+
+			instance := os.Getenv(envSpannerInstanceID)
+			if instance == "" {
+				t.Fatalf("must set %s", envSpannerInstanceID)
+			}
+
+			id := uuid.New()
+			database := fmt.Sprintf("test-%s", id.String()[:18])
+			t.Logf("database %v\n", database)
+
+			config := &Config{
+				Project:  project,
+				Instance: instance,
+				Database: database,
+			}
+
+			client, err := NewClient(ctx, config)
+			if err != nil {
+				t.Fatalf("failed to create spanner client: %v", err)
+			}
+
+			ddl, err := os.ReadFile("testdata/schema.sql")
+			if err != nil {
+				t.Fatalf("failed to read schema file: %v", err)
+			}
+
+			if err := client.CreateDatabase(ctx, "testdata/schema.sql", ddl, test.protoDescriptors); err != nil {
+				t.Fatalf("failed to create database: %v", err)
+			}
+
+			// Verify database was created successfully by checking if we can connect
+			client.Close()
+			client, err = NewClient(ctx, config)
+			if err != nil {
+				t.Fatalf("failed to reconnect to created database: %v", err)
+			}
+
+			// Verify tables were created
+			ri := client.spannerClient.Single().Query(ctx, spanner.Statement{
+				SQL: "SELECT table_name FROM information_schema.tables WHERE table_catalog = '' AND table_name = @table",
+				Params: map[string]interface{}{
+					"table": singerTable,
+				},
+			})
+			defer ri.Stop()
+
+			row, err := ri.Next()
+			if err == iterator.Done {
+				t.Fatalf("failed to find expected table: %v", err)
+			}
+
+			ta := &table{}
+			if err := row.ToStruct(ta); err != nil {
+				t.Fatalf("failed to convert row to struct: %v", err)
+			}
+
+			if want, got := singerTable, ta.TableName; want != got {
+				t.Errorf("want %s, but got %s", want, got)
+			}
+
+			// Clean up
+			client.Close()
+		})
+	}
+}
+
 func testClientWithDatabase(t *testing.T, ctx context.Context) (*Client, func()) {
 	t.Helper()
 
@@ -478,7 +604,7 @@ func testClientWithDatabase(t *testing.T, ctx context.Context) (*Client, func())
 		t.Fatalf("failed to read schema file: %v", err)
 	}
 
-	if err := client.CreateDatabase(ctx, "testdata/schema.sql", ddl); err != nil {
+	if err := client.CreateDatabase(ctx, "testdata/schema.sql", ddl, nil); err != nil {
 		t.Fatalf("failed to create database: %v", err)
 	}
 


### PR DESCRIPTION
<!--
Please read the contribution guidelines and the CLA carefully before
submitting your pull request.

https://cla.developers.google.com/
-->

## WHAT

  - Added --proto_descriptor_file flag to apply, create, load, and migrate up commands
  - Extended core Client methods to accept and handle proto descriptor data alongside DDL operations
  - Modified LoadDDL to return both schema and proto descriptors from existing databases
  - Added test for implemented features

## WHY

  Protocol buffer support is essential for Cloud Spanner applications using proto columns and message types. This feature enables users to:
  - Create and modify proto-enabled databases with proper message definitions
  - Migrate schemas that include proto column types
  - Load existing proto descriptors from databases for backup/export workflows
  - Maintain consistency between application proto definitions and database schema



<!--
Write the motivation why you submit this pull request
-->
