### PR TITLE
Add priority option on migrate up command

### DIFF
--- a/cmd/migrate.go
+++ b/cmd/migrate.go
@@ -73,6 +73,8 @@ func init() {
 	)
 
 	migrateCmd.PersistentFlags().String(flagNameDirectory, "", "Directory that migration files placed (required)")
+
+	migrateUpCmd.PersistentFlags().StringVar(&priority, flagPriority, "", "The priority to apply DML (optional)")
 }
 
 func migrateCreate(c *cobra.Command, args []string) error {
@@ -122,6 +124,14 @@ func migrateUp(c *cobra.Command, args []string) error {
 		limit = n
 	}
 
+	priorityType, err := priorityTypeOf(priority)
+	if err != nil {
+		return &Error{
+			cmd: c,
+			err: err,
+		}
+	}
+
 	client, err := newSpannerClient(ctx, c)
 	if err != nil {
 		return err
@@ -144,7 +154,7 @@ func migrateUp(c *cobra.Command, args []string) error {
 		}
 	}
 
-	return client.ExecuteMigrations(ctx, migrations, limit, migrationTableName)
+	return client.ExecuteMigrations(ctx, migrations, limit, migrationTableName, priorityType)
 }
 
 func migrateVersion(c *cobra.Command, _ []string) error {

--- a/pkg/spanner/client.go
+++ b/pkg/spanner/client.go
@@ -326,7 +326,7 @@ func (c *Client) ApplyPartitionedDML(ctx context.Context, statements []string, p
 	return numAffectedRows, nil
 }
 
-func (c *Client) ExecuteMigrations(ctx context.Context, migrations Migrations, limit int, tableName string) error {
+func (c *Client) ExecuteMigrations(ctx context.Context, migrations Migrations, limit int, tableName string, priorityType PriorityType) error {
 	sort.Sort(migrations)
 
 	version, dirty, err := c.GetSchemaMigrationVersion(ctx, tableName)
@@ -373,14 +373,14 @@ func (c *Client) ExecuteMigrations(ctx context.Context, migrations Migrations, l
 				}
 			}
 		case statementKindDML:
-			if _, err := c.ApplyDML(ctx, m.Statements, PriorityTypeUnspecified); err != nil {
+			if _, err := c.ApplyDML(ctx, m.Statements, priorityType); err != nil {
 				return &Error{
 					Code: ErrorCodeExecuteMigrations,
 					err:  err,
 				}
 			}
 		case statementKindPartitionedDML:
-			if _, err := c.ApplyPartitionedDML(ctx, m.Statements, PriorityTypeUnspecified); err != nil {
+			if _, err := c.ApplyPartitionedDML(ctx, m.Statements, priorityType); err != nil {
 				return &Error{
 					Code: ErrorCodeExecuteMigrations,
 					err:  err,

--- a/pkg/spanner/client_test.go
+++ b/pkg/spanner/client_test.go
@@ -225,7 +225,7 @@ func TestExecuteMigrations(t *testing.T) {
 	}
 
 	// only apply 000002.sql by specifying limit 1.
-	if err := client.ExecuteMigrations(ctx, migrations, 1, migrationTable); err != nil {
+	if err := client.ExecuteMigrations(ctx, migrations, 1, migrationTable, PriorityTypeUnspecified); err != nil {
 		t.Fatalf("failed to execute migration: %v", err)
 	}
 
@@ -233,7 +233,7 @@ func TestExecuteMigrations(t *testing.T) {
 	ensureMigrationColumn(t, ctx, client, "LastName", "STRING(MAX)", "YES")
 	ensureMigrationVersionRecord(t, ctx, client, 2, false)
 
-	if err := client.ExecuteMigrations(ctx, migrations, len(migrations), migrationTable); err != nil {
+	if err := client.ExecuteMigrations(ctx, migrations, len(migrations), migrationTable, PriorityTypeUnspecified); err != nil {
 		t.Fatalf("failed to execute migration: %v", err)
 	}
 


### PR DESCRIPTION
<!--
Please read the contribution guidelines and the CLA carefully before
submitting your pull request.

https://cla.developers.google.com/
-->

## WHAT

As the title suggests.
Similar to https://github.com/cloudspannerecosystem/wrench/pull/37 but this one is for `migrate up` command.

## WHY

To be able to manage the migration impact when it contains DML.
