### PR TITLE
Remove unnecessary range variable capture workaround

### DIFF
--- a/pkg/spanner/client.go
+++ b/pkg/spanner/client.go
@@ -171,7 +171,6 @@ func (c *Client) TruncateAllTables(ctx context.Context) error {
 
 	g := &multierror.Group{}
 	for _, stmt := range stms {
-		stmt := stmt
 		g.Go(func() error {
 			_, err := c.spannerClient.PartitionedUpdate(ctx, stmt)
 			return err


### PR DESCRIPTION
<!--
Please read the contribution guidelines and the CLA carefully before
submitting your pull request.

https://cla.developers.google.com/
-->

## WHAT
SSIA

<!--
Write the change being made with this pull request
-->

## WHY
Go 1.22+ resolves the loop variable capture issue.
Since this repository targets Go 1.23.1, the redundant variable shadowing (stmt := stmt) has been removed.

<!--
Write the motivation why you submit this pull request
-->
