### PR TITLE
Harden --migration_table_name: validation, naming consistency, and truncate support

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,13 @@ $ wrench migrate up --directory ./_examples --migration_table_name DataMigration
 
 The table name must start with a letter and contain only letters, numbers and underscores.
 
-This is useful when you want to manage multiple migration systems in one database (e.g., schema migrations and data migrations separately). Note that the same `--migration_table_name` value must be given to `migrate up`, `migrate version` and `migrate set`, otherwise they operate on the default `SchemaMigrations` table.
+This is useful when you want to manage multiple migration systems in one database (e.g., schema migrations and data migrations separately). Note that the same `--migration_table_name` value must be given to `migrate up`, `migrate version`, `migrate set` and `truncate`, otherwise they operate on the default `SchemaMigrations` table.
+
+`truncate` keeps the migration table so that the database keeps its migration version. If you use a custom table name, pass it to `truncate` as well, otherwise the migration version is deleted:
+
+```sh
+$ wrench truncate --migration_table_name DataMigrations
+```
 
 ### Apply single DDL/DML
 

--- a/README.md
+++ b/README.md
@@ -110,13 +110,15 @@ This executes migrations. This also creates `SchemaMigrations` table into your d
 
 ### Use custom migration table
 
-By default, wrench uses `SchemaMigrations` table to manage migration versions. You can specify a custom table name using `--migration-table-name` flag:
+By default, wrench uses `SchemaMigrations` table to manage migration versions. You can specify a custom table name using `--migration_table_name` flag:
 
 ```sh
-$ wrench migrate up --directory ./_examples --migration-table-name DataMigrations
+$ wrench migrate up --directory ./_examples --migration_table_name DataMigrations
 ```
 
-This is useful when you want to manage multiple migration systems in one database (e.g., schema migrations and data migrations separately).
+The table name must start with a letter and contain only letters, numbers and underscores.
+
+This is useful when you want to manage multiple migration systems in one database (e.g., schema migrations and data migrations separately). Note that the same `--migration_table_name` value must be given to `migrate up`, `migrate version` and `migrate set`, otherwise they operate on the default `SchemaMigrations` table.
 
 ### Apply single DDL/DML
 

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -21,7 +21,9 @@ package cmd
 
 import (
 	"context"
+	"fmt"
 	"path/filepath"
+	"regexp"
 
 	"github.com/spf13/cobra"
 
@@ -44,7 +46,13 @@ const (
 	flagProtoDescriptorFile = "proto_descriptor_file"
 	flagMigrationTableName  = "migration_table_name"
 	defaultSchemaFileName   = "schema.sql"
+
+	defaultMigrationTableName = "SchemaMigrations"
 )
+
+// migrationTableNameRegex is the valid form of a Cloud Spanner table name.
+// The name is embedded into SQL/DDL statements, so it must be validated before use.
+var migrationTableNameRegex = regexp.MustCompile(`^[A-Za-z][A-Za-z0-9_]{0,127}$`)
 
 func newSpannerClient(ctx context.Context, c *cobra.Command) (*spanner.Client, error) {
 	config := &spanner.Config{
@@ -90,6 +98,19 @@ func schemaFilePath(c *cobra.Command) string {
 		filename = defaultSchemaFileName
 	}
 	return filepath.Join(c.Flag(flagNameDirectory).Value.String(), filename)
+}
+
+func getMigrationTableName(c *cobra.Command) (string, error) {
+	name := c.Flag(flagMigrationTableName).Value.String()
+	if name == "" {
+		return defaultMigrationTableName, nil
+	}
+
+	if !migrationTableNameRegex.MatchString(name) {
+		return "", fmt.Errorf("Invalid migration table name: %q. It must start with a letter and contain only letters, numbers and underscores (up to 128 characters).", name)
+	}
+
+	return name, nil
 }
 
 func protoDescriptorFilePath(c *cobra.Command) string {

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -42,7 +42,7 @@ const (
 	flagNode                = "node"
 	flagTimeout             = "timeout"
 	flagProtoDescriptorFile = "proto_descriptor_file"
-	flagMigrationTableName  = "migration-table-name"
+	flagMigrationTableName  = "migration_table_name"
 	defaultSchemaFileName   = "schema.sql"
 )
 

--- a/cmd/migrate.go
+++ b/cmd/migrate.go
@@ -25,7 +25,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"regexp"
 	"strconv"
 	"strings"
 
@@ -35,13 +34,8 @@ import (
 )
 
 const (
-	migrationsDirName         = "migrations"
-	defaultMigrationTableName = "SchemaMigrations"
+	migrationsDirName = "migrations"
 )
-
-// migrationTableNameRegex is the valid form of a Cloud Spanner table name.
-// The name is embedded into SQL/DDL statements, so it must be validated before use.
-var migrationTableNameRegex = regexp.MustCompile(`^[A-Za-z][A-Za-z0-9_]{0,127}$`)
 
 // migrateCmd represents the migrate command
 var migrateCmd = &cobra.Command{
@@ -227,19 +221,6 @@ func migrateVersion(c *cobra.Command, _ []string) error {
 	fmt.Println(v)
 
 	return nil
-}
-
-func getMigrationTableName(c *cobra.Command) (string, error) {
-	name := c.Flag(flagMigrationTableName).Value.String()
-	if name == "" {
-		return defaultMigrationTableName, nil
-	}
-
-	if !migrationTableNameRegex.MatchString(name) {
-		return "", fmt.Errorf("Invalid migration table name: %q. It must start with a letter and contain only letters, numbers and underscores (up to 128 characters).", name)
-	}
-
-	return name, nil
 }
 
 func migrateSet(c *cobra.Command, args []string) error {

--- a/cmd/migrate.go
+++ b/cmd/migrate.go
@@ -25,6 +25,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strconv"
 	"strings"
 
@@ -37,6 +38,10 @@ const (
 	migrationsDirName         = "migrations"
 	defaultMigrationTableName = "SchemaMigrations"
 )
+
+// migrationTableNameRegex is the valid form of a Cloud Spanner table name.
+// The name is embedded into SQL/DDL statements, so it must be validated before use.
+var migrationTableNameRegex = regexp.MustCompile(`^[A-Za-z][A-Za-z0-9_]{0,127}$`)
 
 // migrateCmd represents the migrate command
 var migrateCmd = &cobra.Command{
@@ -136,13 +141,21 @@ func migrateUp(c *cobra.Command, args []string) error {
 		}
 	}
 
+	migrationTableName, err := getMigrationTableName(c)
+	if err != nil {
+		return &Error{
+			cmd: c,
+			err: err,
+		}
+	}
+
 	client, err := newSpannerClient(ctx, c)
 	if err != nil {
 		return err
 	}
 	defer client.Close()
 
-	if err = client.EnsureMigrationTable(ctx, getMigrationTableName(c)); err != nil {
+	if err = client.EnsureMigrationTable(ctx, migrationTableName); err != nil {
 		return &Error{
 			cmd: c,
 			err: err,
@@ -170,12 +183,20 @@ func migrateUp(c *cobra.Command, args []string) error {
 		}
 	}
 
-	return client.ExecuteMigrations(ctx, migrations, limit, getMigrationTableName(c), priorityType, protoDescriptor)
+	return client.ExecuteMigrations(ctx, migrations, limit, migrationTableName, priorityType, protoDescriptor)
 }
 
 func migrateVersion(c *cobra.Command, _ []string) error {
 	ctx, cancel := context.WithTimeout(c.Context(), timeout)
 	defer cancel()
+
+	migrationTableName, err := getMigrationTableName(c)
+	if err != nil {
+		return &Error{
+			cmd: c,
+			err: err,
+		}
+	}
 
 	client, err := newSpannerClient(ctx, c)
 	if err != nil {
@@ -183,14 +204,14 @@ func migrateVersion(c *cobra.Command, _ []string) error {
 	}
 	defer client.Close()
 
-	if err = client.EnsureMigrationTable(ctx, getMigrationTableName(c)); err != nil {
+	if err = client.EnsureMigrationTable(ctx, migrationTableName); err != nil {
 		return &Error{
 			cmd: c,
 			err: err,
 		}
 	}
 
-	v, _, err := client.GetSchemaMigrationVersion(ctx, getMigrationTableName(c))
+	v, _, err := client.GetSchemaMigrationVersion(ctx, migrationTableName)
 	if err != nil {
 		var se *spanner.Error
 		if errors.As(err, &se) && se.Code == spanner.ErrorCodeNoMigration {
@@ -208,8 +229,17 @@ func migrateVersion(c *cobra.Command, _ []string) error {
 	return nil
 }
 
-func getMigrationTableName(c *cobra.Command) string {
-	return c.Flag(flagMigrationTableName).Value.String()
+func getMigrationTableName(c *cobra.Command) (string, error) {
+	name := c.Flag(flagMigrationTableName).Value.String()
+	if name == "" {
+		return defaultMigrationTableName, nil
+	}
+
+	if !migrationTableNameRegex.MatchString(name) {
+		return "", fmt.Errorf("Invalid migration table name: %q. It must start with a letter and contain only letters, numbers and underscores (up to 128 characters).", name)
+	}
+
+	return name, nil
 }
 
 func migrateSet(c *cobra.Command, args []string) error {
@@ -230,20 +260,28 @@ func migrateSet(c *cobra.Command, args []string) error {
 		}
 	}
 
-	client, err := newSpannerClient(ctx, c)
+	migrationTableName, err := getMigrationTableName(c)
 	if err != nil {
-		return err
-	}
-	defer client.Close()
-
-	if err = client.EnsureMigrationTable(ctx, getMigrationTableName(c)); err != nil {
 		return &Error{
 			cmd: c,
 			err: err,
 		}
 	}
 
-	if err := client.SetSchemaMigrationVersion(ctx, uint(version), false, getMigrationTableName(c)); err != nil {
+	client, err := newSpannerClient(ctx, c)
+	if err != nil {
+		return err
+	}
+	defer client.Close()
+
+	if err = client.EnsureMigrationTable(ctx, migrationTableName); err != nil {
+		return &Error{
+			cmd: c,
+			err: err,
+		}
+	}
+
+	if err := client.SetSchemaMigrationVersion(ctx, uint(version), false, migrationTableName); err != nil {
 		return &Error{
 			cmd: c,
 			err: err,

--- a/cmd/migrate_test.go
+++ b/cmd/migrate_test.go
@@ -125,8 +125,8 @@ func TestGetMigrationTableName(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			c := &cobra.Command{}
-			c.Flags().String("migration-table-name", "SchemaMigrations", "")
-			if err := c.Flags().Set("migration-table-name", tc.flagValue); err != nil {
+			c.Flags().String("migration_table_name", "SchemaMigrations", "")
+			if err := c.Flags().Set("migration_table_name", tc.flagValue); err != nil {
 				t.Fatal(err)
 			}
 

--- a/cmd/migrate_test.go
+++ b/cmd/migrate_test.go
@@ -23,6 +23,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/cloudspannerecosystem/wrench/cmd"
@@ -78,10 +79,11 @@ func TestGetMigrationTableName(t *testing.T) {
 		name      string
 		flagValue string
 		want      string
+		wantErr   bool
 	}{
 		{
 			name:      "default value",
-			flagValue: "",
+			flagValue: "SchemaMigrations",
 			want:      "SchemaMigrations",
 		},
 		{
@@ -89,15 +91,55 @@ func TestGetMigrationTableName(t *testing.T) {
 			flagValue: "DataMigrations",
 			want:      "DataMigrations",
 		},
+		{
+			name:      "table name with underscore and digits",
+			flagValue: "Data_Migrations2",
+			want:      "Data_Migrations2",
+		},
+		{
+			name:      "empty value falls back to default",
+			flagValue: "",
+			want:      "SchemaMigrations",
+		},
+		{
+			name:      "table name starting with digit",
+			flagValue: "1Migrations",
+			wantErr:   true,
+		},
+		{
+			name:      "table name with invalid character",
+			flagValue: "Data-Migrations",
+			wantErr:   true,
+		},
+		{
+			name:      "table name with SQL injection",
+			flagValue: "SchemaMigrations` WHERE FALSE UNION ALL SELECT 1, FALSE FROM `SchemaMigrations",
+			wantErr:   true,
+		},
+		{
+			name:      "too long table name",
+			flagValue: strings.Repeat("A", 129),
+			wantErr:   true,
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			c := &cobra.Command{}
 			c.Flags().String("migration-table-name", "SchemaMigrations", "")
-			if tc.flagValue != "" {
-				c.Flags().Set("migration-table-name", tc.flagValue)
+			if err := c.Flags().Set("migration-table-name", tc.flagValue); err != nil {
+				t.Fatal(err)
 			}
-			got := cmd.GetMigrationTableName(c)
+
+			got, err := cmd.GetMigrationTableName(c)
+			if tc.wantErr {
+				if err == nil {
+					t.Errorf("want error, but got nil (value: %s)", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("want no error, but got %v", err)
+			}
 			if got != tc.want {
 				t.Errorf("want %s, but got %s", tc.want, got)
 			}

--- a/cmd/truncate.go
+++ b/cmd/truncate.go
@@ -31,9 +31,21 @@ var truncateCmd = &cobra.Command{
 	RunE:  truncate,
 }
 
+func init() {
+	truncateCmd.Flags().String(flagMigrationTableName, defaultMigrationTableName, "Name of the migration tracking table to be kept")
+}
+
 func truncate(c *cobra.Command, _ []string) error {
 	ctx, cancel := context.WithTimeout(c.Context(), timeout)
 	defer cancel()
+
+	migrationTableName, err := getMigrationTableName(c)
+	if err != nil {
+		return &Error{
+			err: err,
+			cmd: c,
+		}
+	}
 
 	client, err := newSpannerClient(ctx, c)
 	if err != nil {
@@ -41,7 +53,7 @@ func truncate(c *cobra.Command, _ []string) error {
 	}
 	defer client.Close()
 
-	err = client.TruncateAllTables(ctx)
+	err = client.TruncateAllTables(ctx, migrationTableName)
 	if err != nil {
 		return &Error{
 			err: err,

--- a/pkg/spanner/client.go
+++ b/pkg/spanner/client.go
@@ -24,6 +24,7 @@ import (
 	"errors"
 	"fmt"
 	"sort"
+	"strings"
 
 	"cloud.google.com/go/spanner"
 	databasev1 "cloud.google.com/go/spanner/admin/database/apiv1"
@@ -157,7 +158,9 @@ func (c *Client) TruncateAllTables(ctx context.Context, migrationTableName strin
 			return err
 		}
 
-		if t.TableName == migrationTableName {
+		// Cloud Spanner identifiers are case insensitive, while INFORMATION_SCHEMA
+		// returns the name as it was declared.
+		if strings.EqualFold(t.TableName, migrationTableName) {
 			return nil
 		}
 

--- a/pkg/spanner/client.go
+++ b/pkg/spanner/client.go
@@ -143,7 +143,9 @@ func (c *Client) DropDatabase(ctx context.Context) error {
 	return nil
 }
 
-func (c *Client) TruncateAllTables(ctx context.Context) error {
+// TruncateAllTables deletes all rows of all tables except the migration table
+// named migrationTableName, so that the database keeps its migration version.
+func (c *Client) TruncateAllTables(ctx context.Context, migrationTableName string) error {
 	var stms []spanner.Statement
 
 	ri := c.spannerClient.Single().Query(ctx, spanner.Statement{
@@ -155,7 +157,7 @@ func (c *Client) TruncateAllTables(ctx context.Context) error {
 			return err
 		}
 
-		if t.TableName == "SchemaMigrations" {
+		if t.TableName == migrationTableName {
 			return nil
 		}
 

--- a/pkg/spanner/client.go
+++ b/pkg/spanner/client.go
@@ -423,7 +423,7 @@ func (c *Client) ExecuteMigrations(ctx context.Context, migrations Migrations, l
 
 func (c *Client) GetSchemaMigrationVersion(ctx context.Context, tableName string) (uint, bool, error) {
 	stmt := spanner.Statement{
-		SQL: `SELECT Version, Dirty FROM ` + tableName + ` LIMIT 1`,
+		SQL: fmt.Sprintf("SELECT Version, Dirty FROM `%s` LIMIT 1", tableName),
 	}
 	iter := c.spannerClient.Single().Query(ctx, stmt)
 	defer iter.Stop()
@@ -487,7 +487,7 @@ func (c *Client) EnsureMigrationTable(ctx context.Context, tableName string) err
 		return nil
 	}
 
-	stmt := fmt.Sprintf(`CREATE TABLE %s (
+	stmt := fmt.Sprintf("CREATE TABLE `%s` ("+`
     Version INT64 NOT NULL,
     Dirty    BOOL NOT NULL
 	) PRIMARY KEY(Version)`, tableName)

--- a/pkg/spanner/client_test.go
+++ b/pkg/spanner/client_test.go
@@ -32,8 +32,9 @@ import (
 )
 
 const (
-	singerTable    = "Singers"
-	migrationTable = "SchemaMigrations"
+	singerTable          = "Singers"
+	migrationTable       = "SchemaMigrations"
+	customMigrationTable = "DataMigrations"
 )
 
 type (
@@ -145,6 +146,95 @@ func TestApplyDDLFile(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestTruncateAllTables(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	tests := map[string]struct {
+		// migrationTableName is the table to be kept.
+		migrationTableName string
+		// wantKeptTables are the tables that must still have their row.
+		wantKeptTables []string
+		// wantTruncatedTables are the tables that must be empty.
+		wantTruncatedTables []string
+	}{
+		"keep default migration table": {
+			migrationTableName:  migrationTable,
+			wantKeptTables:      []string{migrationTable},
+			wantTruncatedTables: []string{customMigrationTable},
+		},
+		"keep custom migration table": {
+			migrationTableName:  customMigrationTable,
+			wantKeptTables:      []string{customMigrationTable},
+			wantTruncatedTables: []string{migrationTable},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			client, done := testClientWithDatabase(t, ctx)
+			defer done()
+
+			if err := client.EnsureMigrationTable(ctx, customMigrationTable); err != nil {
+				t.Fatalf("failed to ensure migration table: %v", err)
+			}
+
+			_, err := client.spannerClient.Apply(
+				ctx,
+				[]*spanner.Mutation{
+					spanner.Insert(singerTable, []string{"SingerID", "FirstName"}, []interface{}{"1", "Foo"}),
+					spanner.Insert(migrationTable, []string{"Version", "Dirty"}, []interface{}{1, false}),
+					spanner.Insert(customMigrationTable, []string{"Version", "Dirty"}, []interface{}{1, false}),
+				},
+			)
+			if err != nil {
+				t.Fatalf("failed to apply mutation: %v", err)
+			}
+
+			if err := client.TruncateAllTables(ctx, test.migrationTableName); err != nil {
+				t.Fatalf("failed to truncate all tables: %v", err)
+			}
+
+			if got := countRows(t, ctx, client, singerTable); got != 0 {
+				t.Errorf("%s want 0 rows, but got %d", singerTable, got)
+			}
+
+			for _, table := range test.wantKeptTables {
+				if got := countRows(t, ctx, client, table); got != 1 {
+					t.Errorf("%s want 1 row, but got %d", table, got)
+				}
+			}
+
+			for _, table := range test.wantTruncatedTables {
+				if got := countRows(t, ctx, client, table); got != 0 {
+					t.Errorf("%s want 0 rows, but got %d", table, got)
+				}
+			}
+		})
+	}
+}
+
+func countRows(t *testing.T, ctx context.Context, client *Client, tableName string) int64 {
+	t.Helper()
+
+	ri := client.spannerClient.Single().Query(ctx, spanner.Statement{
+		SQL: fmt.Sprintf("SELECT COUNT(*) FROM `%s`", tableName),
+	})
+	defer ri.Stop()
+
+	row, err := ri.Next()
+	if err != nil {
+		t.Fatalf("failed to count rows of %s: %v", tableName, err)
+	}
+
+	var count int64
+	if err := row.Columns(&count); err != nil {
+		t.Fatalf("failed to read count of %s: %v", tableName, err)
+	}
+
+	return count
 }
 
 func TestApplyDMLFile(t *testing.T) {

--- a/pkg/spanner/client_test.go
+++ b/pkg/spanner/client_test.go
@@ -23,6 +23,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strings"
 	"testing"
 
 	"cloud.google.com/go/spanner"
@@ -169,6 +170,13 @@ func TestTruncateAllTables(t *testing.T) {
 			migrationTableName:  customMigrationTable,
 			wantKeptTables:      []string{customMigrationTable},
 			wantTruncatedTables: []string{migrationTable},
+		},
+		// Cloud Spanner identifiers are case insensitive, so a name given in a
+		// different case still points at the same table.
+		"keep migration table given in a different case": {
+			migrationTableName:  strings.ToLower(migrationTable),
+			wantKeptTables:      []string{migrationTable},
+			wantTruncatedTables: []string{customMigrationTable},
 		},
 	}
 


### PR DESCRIPTION
<!--
Please read the contribution guidelines and the CLA carefully before
submitting your pull request.

https://cla.developers.google.com/
-->

## WHY

#152 added the `--migration-table-name` flag. It works, but it left three issues behind.

1. **The table name is interpolated into SQL/DDL without any validation.**
   `GetSchemaMigrationVersion` builds `"SELECT Version, Dirty FROM " + tableName + " LIMIT 1"`
   and `EnsureMigrationTable` builds `fmt.Sprintf("CREATE TABLE %s ...")`. Until #152 the
   name was a compile-time constant, so this was safe. Now it is user input, and a value
   passed from a CI variable can change the statement. Passing an empty string also produced
   a confusing `CREATE TABLE  (` error from Cloud Spanner instead of a clear message.

2. **The flag name does not follow the existing convention.**
   Every other multi-word flag in wrench uses snake_case: `credentials_file`, `schema_file`,
   `proto_descriptor_file`. Only this one was kebab-case.

3. **`truncate` silently destroys the migration version when a custom table is used.**
   `TruncateAllTables` skips the literal `SchemaMigrations` table so that a truncated
   database keeps its migration version. With a custom table name, that exclusion does not
   match, the version row is deleted, and the next `migrate up` re-applies every migration
   from version 0 — failing with errors like `Duplicate column name ...` for DDL migrations.
   This is easy to hit because `truncate` is a routine command in development and CI, and
   the failure surfaces later in an unrelated command.

## WHAT

**Validate the table name and quote it (507e775)**

- Validate against `^[A-Za-z][A-Za-z0-9_]{0,127}$` in `getMigrationTableName`, before
  connecting to Cloud Spanner, matching the Cloud Spanner table name rules
- Fall back to the default `SchemaMigrations` when the flag is empty, consistently with
  `schemaFilePath()`
- Quote the table name with backticks in `GetSchemaMigrationVersion` and
  `EnsureMigrationTable`, as `TruncateAllTables` already does
- Resolve the table name once per command instead of on every use

**Rename the flag to `--migration_table_name` (6ec6969)**

- The flag is not included in any release yet (latest tag is `v1.13.5`), so it is renamed
  without keeping an alias

**Keep the specified migration table on `truncate` (6337f22)**

- `TruncateAllTables` now takes the migration table name and excludes that table
- `truncate` accepts `--migration_table_name`
- `getMigrationTableName` moved to `cmd/cmd.go` since it is no longer migrate specific

Docs are updated: the README describes the name restriction, and notes that the same
`--migration_table_name` value must be given to `migrate up` / `version` / `set` and
`truncate`.

## Testing

- `TestGetMigrationTableName` covers the empty fallback, a leading digit, an invalid
  character, a backtick-based injection string, and a name longer than 128 characters
- `TestTruncateAllTables` is new and covers both the default and a custom table name.
  Verified that it fails against the previous hardcoded exclusion
- Full suite passes against the Spanner emulator
- Manually verified against the emulator: `truncate --migration_table_name Data_Migrations`
  keeps the version, while `truncate` without the flag drops it to `No migrations.`ion why you submit this pull request
-->
